### PR TITLE
feat(auth): 로그인 페이지 및 카카오 OAuth 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import AuthorGuides from "@/pages/AuthorGuides";
 import GroupDetail from "@/pages/GroupDetail";
 import Profile from "@/pages/Profile";
 import Auth from "@/pages/Auth";
+import AuthCallback from "@/pages/AuthCallback";
 import Notifications from "@/pages/Notifications";
 import InviteLanding from "@/pages/InviteLanding";
 import Invitations from "@/pages/Invitations";
@@ -36,6 +37,7 @@ function App() {
               <Route path="/group/:groupId" element={<GroupDetail />} />
               <Route path="/profile" element={<Profile />} />
               <Route path="/auth" element={<Auth />} />
+              <Route path="/auth/callback" element={<AuthCallback />} />
               <Route path="/notifications" element={<Notifications />} />
               <Route path="/invite/:inviteCode" element={<InviteLanding />} />
               <Route path="/invitations" element={<Invitations />} />

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,18 +1,29 @@
-
 import { useState, useEffect, createContext, useContext, ReactNode } from 'react';
+import api from '@/lib/api';
 
-interface User {
-  id: string;
-  email: string;
-  name?: string;
+// 서버가 쿠키(JWT)를 세팅/검증하고, 프론트는 /auth/me 로 현재 사용자만 조회하는 구조입니다.
+// 카카오는 버튼 클릭 -> 백엔드에서 받은 authorizeUrl 로 이동 -> 콜백에서 쿠키 세팅 -> 홈으로 리다이렉트 ->
+// 앱이 부팅되며 /auth/me 호출로 사용자 상태(user) 하이드레이션.
+
+export interface User {
+  id: string | number;
+  email?: string | null;
+  name?: string | null;
+  nickname?: string | null;
+  profileImageUrl?: string | null;
 }
 
 interface AuthContextType {
   user: User | null;
   loading: boolean;
+  // 로컬 아이디/패스워드 로그인(있다면)
   signIn: (email: string, password: string) => Promise<{ error: any }>;
   signUp: (email: string, password: string, name?: string) => Promise<{ error: any }>;
   signOut: () => Promise<void>;
+  // 카카오 로그인 시작
+  startKakaoLogin: () => Promise<void>;
+  // 수동으로 /auth/me 재조회
+  refreshMe: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -29,37 +40,56 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(false);
 
+  // 앱 시작 시 쿠키 기반 세션 하이드레이션
   useEffect(() => {
-    // Check for existing session in localStorage
-    const storedUser = localStorage.getItem('user');
-    if (storedUser) {
-      setUser(JSON.parse(storedUser));
-    }
+    // 첫 렌더에서만 한번 불러오기
+    refreshMe().catch(() => void 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const refreshMe = async () => {
+    try {
+      setLoading(true);
+      const { data } = await api.get('/auth/me'); // 200이면 로그인 상태
+      // 백엔드에서 내려주는 필드 이름에 맞춰 매핑(필요 시 조정)
+      const mapped: User = {
+        id: data.id ?? data.memberId ?? data.user?.id,
+        email: data.email ?? data.user?.email ?? null,
+        name: data.name ?? data.user?.name ?? data.nickname ?? null,
+        nickname: data.nickname ?? data.user?.nickname ?? null,
+        profileImageUrl: data.profileImageUrl ?? data.user?.profileImageUrl ?? null,
+      };
+      setUser(mapped);
+    } catch (e) {
+      setUser(null); // 401 등은 비로그인으로 취급
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 카카오 로그인 시작: 백엔드에서 authorizeUrl 받아 리다이렉트
+  const startKakaoLogin = async () => {
+    setLoading(true);
+    try {
+      const { data } = await api.get<{ authorizeUrl: string }>('/auth/kakao/login-url');
+      // 백엔드가 state를 쓰고 싶다면 여기서 붙여도 됨
+      window.location.href = data.authorizeUrl;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 로컬 로그인
   const signIn = async (email: string, password: string) => {
     try {
       setLoading(true);
-      // TODO: Replace with your backend API call
-      const response = await fetch('/api/auth/signin', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ email, password }),
-      });
-      
-      if (!response.ok) {
-        throw new Error('Login failed');
-      }
-      
-      const userData = await response.json();
-      setUser(userData.user);
-      localStorage.setItem('user', JSON.stringify(userData.user));
-      
+      // ✅ 엔드포인트 변경: /auth/signin -> /auth/login
+      await api.post('/auth/login', { username: email, password });
+      // 로그인 시 쿠키를 심는 구조이므로, 유저 정보는 /auth/me로 다시 가져온다.
+      await refreshMe();
       return { error: null };
     } catch (error: any) {
-      return { error: { message: error.message } };
+      return { error: { message: error?.response?.data?.message || error.message } };
     } finally {
       setLoading(false);
     }
@@ -68,43 +98,41 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const signUp = async (email: string, password: string, name?: string) => {
     try {
       setLoading(true);
-      // TODO: Replace with your backend API call
-      const response = await fetch('/api/auth/signup', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ email, password, name }),
-      });
-      
-      if (!response.ok) {
-        throw new Error('Registration failed');
-      }
-      
+      await api.post('/auth/signup', { email, password, name });
       return { error: null };
     } catch (error: any) {
-      return { error: { message: error.message } };
+      return { error: { message: error?.response?.data?.message || error.message } };
     } finally {
       setLoading(false);
     }
   };
 
   const signOut = async () => {
-    setUser(null);
-    localStorage.removeItem('user');
+    try {
+      setLoading(true);
+      // 서버 쿠키 삭제(엔드포인트가 없으면 무시 가능)
+      await api.post('/auth/logout');
+    } catch {
+      // ignore
+    } finally {
+      setUser(null);
+      setLoading(false);
+    }
   };
 
-  const value = {
+  const value: AuthContextType = {
     user,
     loading,
     signIn,
     signUp,
     signOut,
+    startKakaoLogin,
+    refreshMe,
   };
 
   return (
-    <AuthContext.Provider value={value}>
-      {children}
-    </AuthContext.Provider>
+      <AuthContext.Provider value={value}>
+        {children}
+      </AuthContext.Provider>
   );
 };

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,0 +1,8 @@
+// src/lib/http.ts
+import axios from "axios";
+
+export const http = axios.create({
+    baseURL: "/api",
+    withCredentials: true,   // ✅ 쿠키 포함
+    headers: { "Content-Type": "application/json" },
+});

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,25 +1,44 @@
-
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { ArrowLeft, Eye, EyeOff } from "lucide-react";
+import { ArrowLeft, Eye, EyeOff, Loader2 } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
 
 const Auth = () => {
   const [isLogin, setIsLogin] = useState(true);
   const [showPassword, setShowPassword] = useState(false);
-  const [email, setEmail] = useState("");
+  const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [name, setName] = useState("");
   const [loading, setLoading] = useState(false);
-  
-  const { signIn, signUp } = useAuth();
+  const [kakaoLoading, setKakaoLoading] = useState(false);
+
+  const { signIn, signUp, startKakaoLogin } = useAuth();
   const { toast } = useToast();
   const navigate = useNavigate();
+
+  const handleKakaoLogin = async () => {
+    try {
+      setKakaoLoading(true);
+      const res = await fetch("/api/auth/kakao/login-url", { credentials: "include" });
+      if (!res.ok) throw new Error("카카오 로그인 URL을 가져오지 못했습니다.");
+      const data: { authorizeUrl: string } = await res.json();
+      // 카카오 동의 화면으로 이동 (백엔드에서 redirect_uri 로 콜백되고, 거기서 우리 JWT 쿠키를 세팅하고 프론트로 302 리다이렉트됩니다)
+      window.location.href = data.authorizeUrl;
+    } catch (e: any) {
+      toast({
+        title: "카카오 로그인 준비 실패",
+        description: e?.message ?? "다시 시도해주세요.",
+        variant: "destructive",
+      });
+    } finally {
+      setKakaoLoading(false);
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -27,7 +46,7 @@ const Auth = () => {
 
     try {
       if (isLogin) {
-        const { error } = await signIn(email, password);
+        const { error } = await signIn(username, password);
         if (error) {
           toast({
             title: "로그인 실패",
@@ -42,7 +61,7 @@ const Auth = () => {
           navigate("/");
         }
       } else {
-        const { error } = await signUp(email, password, name);
+        const { error } = await signUp(username, password, name);
         if (error) {
           toast({
             title: "회원가입 실패",
@@ -107,19 +126,19 @@ const Auth = () => {
                     />
                   </div>
                 )}
-                
+
                 <div className="space-y-2">
-                  <Label htmlFor="email">아이디 (이메일)</Label>
+                  <Label htmlFor="username">아이디</Label>
                   <Input
-                    id="email"
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    placeholder="example@email.com"
+                    id="username"
+                    type="text"
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                    placeholder="아이디를 입력하세요"
                     required
                   />
                 </div>
-                
+
                 <div className="space-y-2">
                   <Label htmlFor="password">비밀번호</Label>
                   <div className="relative">
@@ -150,6 +169,42 @@ const Auth = () => {
                   {loading ? "처리 중..." : (isLogin ? "로그인" : "회원가입")}
                 </Button>
               </form>
+
+              {/* Divider */}
+              <div className="flex items-center gap-3 py-2">
+                <div className="flex-1 h-px bg-border" />
+                <span className="text-xs text-muted-foreground">또는</span>
+                <div className="flex-1 h-px bg-border" />
+              </div>
+
+              {/* Kakao Login */}
+              <Button
+                type="button"
+                onClick={handleKakaoLogin}
+                disabled={kakaoLoading}
+                className="w-full bg-[#FEE500] text-black hover:opacity-90"
+              >
+                {kakaoLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    카카오로 이동 중...
+                  </>
+                ) : (
+                  <>
+                    {/* Simple Kakao bubble icon (SVG) */}
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="currentColor"
+                      className="mr-2 h-4 w-4"
+                      aria-hidden
+                    >
+                      <path d="M12 3C6.477 3 2 6.582 2 11c0 2.63 1.69 4.94 4.276 6.305-.153.574-.555 2.07-.64 2.4-.101.396.144.39.304.284.125-.083 1.99-1.36 2.79-1.91.417.06.846.091 1.27.091 5.523 0 10-3.582 10-8s-4.477-7.17-10-7.17Z" />
+                    </svg>
+                    카카오로 계속하기
+                  </>
+                )}
+              </Button>
 
               <div className="mt-6 text-center">
                 <Button

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@/hooks/useAuth";
+
+const AuthCallback = () => {
+    const { user, loading, refreshMe } = useAuth();
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        // AuthProvider가 로드 시 이미 refreshMe를 실행하고 있을 수 있습니다.
+        // 하지만 콜백 페이지에 도달하는 시점은 명시적으로 다시 호출하는 것이 안전합니다.
+        refreshMe().finally(() => {
+            navigate("/", { replace: true });
+        });
+    }, [refreshMe, navigate]);
+
+    return (
+        <div className="min-h-screen grid place-items-center bg-background">
+            <div className="text-center">
+                <p className="text-lg font-semibold text-foreground">로그인 처리 중...</p>
+                <p className="text-sm text-muted-foreground">잠시만 기다려주세요.</p>
+            </div>
+        </div>
+    );
+};
+
+export default AuthCallback;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    },
   },
   plugins: [
     react(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,13 @@ import { componentTagger } from "lovable-tagger";
 export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
-    port: 8080,
+    port: 5173,
+    strictPort: true,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      }
     },
   },
   plugins: [


### PR DESCRIPTION
### 📌 목적 (Why)
- 프론트엔드 로그인 화면에서 **일반 로그인 & 카카오 OAuth 로그인**을 모두 지원하기 위함
- 백엔드에서 발급된 JWT(access/refresh)를 쿠키 기반으로 세션 관리 → 로그인 상태 UI 반영

---

### 🔧 변경 사항 (What)
- **Auth.tsx**:  
  - 로그인/회원가입 폼 UI 구현  
  - 카카오 로그인 버튼 추가 → `/api/auth/kakao/login-url` 호출 후 리다이렉트
- **useAuth.tsx**:  
  - `startKakaoLogin()`, `refreshMe()` 로직 추가  
  - `/auth/me` API 연동으로 로그인 상태 하이드레이션
- **Index.tsx (홈 화면)**:  
  - 로그인 여부에 따라 Hero 버튼/그룹 목록 UI 분기 처리
- **기타**:  
  - axios 공용 API 유틸 추가 (`/lib/api.ts`)  
  - Vite proxy 설정으로 `/api` → `http://localhost:8080` 프록시  

---

### ✅ 테스트 결과 (Test)
- [x] 로그인 성공 시 → 홈화면 상단에 로그인 상태 UI 반영  
- [x] 카카오 로그인 성공 시 → JWT 쿠키 세팅 + `/auth/me` 조회 정상 동작  
- [x] 로그인 실패 시 → 토스트 알림 표시  
- [x] 로그아웃 시 → 쿠키 삭제 후 비로그인 화면 노출  

---

### 🔗 이슈 링크 (Related Issues)
- Closes #7  (카카오 OAuth 로그인 연동)   
- Parent: Epic#1 (MVP 인증/보안)  