### PR TITLE
feat(frontend): 그룹 일정 캘린더 CRUD 및 참여 UI 구현

### DIFF
--- a/src/components/GroupCalendar.tsx
+++ b/src/components/GroupCalendar.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+// src/components/GroupCalendar.tsx
+import { useEffect, useMemo, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
@@ -8,75 +9,127 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Plus, Calendar as CalendarIcon, Clock, Users, Pencil, Trash2 } from "lucide-react";
+// ⬇️ put, del 실제로 사용
+import { get, post, put, del } from "@/lib/http";
+import { useToast } from "@/hooks/use-toast";
 
 interface GroupCalendarProps {
   groupId: string;
 }
 
+/** ===== 서버 DTO ===== */
+type ScheduleItemDto = {
+  id: number;
+  title: string;
+  location?: string;
+  startTime: string; // ISO-8601
+  endTime: string;   // ISO-8601
+  attending: {
+    count: number; // 전체 참석 수
+    sample: { memberId: number; displayName: string }[];
+    hasMore: boolean;
+    isMine: boolean; // 나의 참석 여부
+  };
+  overlap: boolean;
+};
+
+type CreateReqDto = {
+  title: string;
+  description?: string;
+  location?: string;
+  startTime: string; // ISO-8601
+  endTime: string;   // ISO-8601
+};
+
+type UpdateReqDto = Partial<CreateReqDto>; // 부분 수정 허용
+
+/** ===== 화면 모델 ===== */
 type ScheduleType = "arrival" | "activity" | "departure";
 
 interface Schedule {
-  id: string;
+  id: number;
   title: string;
   date: Date;
-  startTime: string;
-  endTime: string;
+  startTime: string; // "HH:mm"
+  endTime: string;   // "HH:mm"
   type: ScheduleType | string;
-  availableMembers: string[];
-  allMembers: string[];
+  availableMembers: string[]; // 샘플 표시용
+  totalAttendeeCount: number; // 전체 수
+  isMine: boolean;            // 내가 현재 GOING인지
 }
 
-interface RecommendedSchedule {
-  title: string;
-  startTime: string;
-  endTime: string;
-  type: ScheduleType;
-  source: "popular" | "recent" | "ai";
-  score?: number;
-}
-
-// ---- Mock 데이터 ----
-const mockSchedules: Schedule[] = [
-  {
-    id: "1",
-    title: "제주도 도착",
-    date: new Date(2025, 2, 15),
-    startTime: "10:00",
-    endTime: "11:00",
-    type: "arrival",
-    availableMembers: ["김민수", "이지은"],
-    allMembers: ["김민수", "이지은", "박정우", "최유리"]
-  },
-  {
-    id: "2",
-    title: "성산일출봉 관광",
-    date: new Date(2025, 2, 16),
-    startTime: "06:00",
-    endTime: "08:00",
-    type: "activity",
-    availableMembers: ["김민수", "박정우", "최유리"],
-    allMembers: ["김민수", "이지은", "박정우", "최유리"]
-  }
-];
-
-const allGroupMembers = ["김민수", "이지은", "박정우", "최유리"];
-
-// 유틸: Date → yyyy-MM-dd
+/** ===== 유틸 ===== */
+// yyyy-MM-dd
 const toYmd = (d: Date) => {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
   const day = String(d.getDate()).padStart(2, "0");
   return `${y}-${m}-${day}`;
 };
-// 유틸: yyyy-MM-dd → Date
-const fromYmd = (v: string) => {
-  const [y, m, d] = v.split("-").map(Number);
-  return new Date(y, (m || 1) - 1, d || 1);
+
+// 명시적 오프셋으로 ISO 만들기 (타임존 흔들림 방지)
+const toIsoWithOffset = (y: number, m0: number, d: number, hh = 0, mm = 0, ss = 0, ms = 0) => {
+  const local = new Date(y, m0, d, hh, mm, ss, ms);
+  const pad = (n: number, w = 2) => String(n).padStart(w, "0");
+  const tzMin = -local.getTimezoneOffset(); // KST면 -540 → +09:00
+  const sign = tzMin >= 0 ? "+" : "-";
+  const abs = Math.abs(tzMin);
+  const offH = Math.trunc(abs / 60);
+  const offM = abs % 60;
+  return `${local.getFullYear()}-${pad(local.getMonth() + 1)}-${pad(local.getDate())}T${pad(local.getHours())}:${pad(local.getMinutes())}:${pad(local.getSeconds())}${sign}${pad(offH)}:${pad(offM)}`;
+};
+const startOfDayISO = (d: Date) => toIsoWithOffset(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0);
+const endOfDayISO = (d: Date) => toIsoWithOffset(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999);
+
+const toLocalDateAndTime = (iso: string) => {
+  const dt = new Date(iso);
+  const hh = String(dt.getHours()).padStart(2, "0");
+  const mm = String(dt.getMinutes()).padStart(2, "0");
+  return {
+    date: new Date(dt.getFullYear(), dt.getMonth(), dt.getDate()),
+    time: `${hh}:${mm}`,
+  };
 };
 
+const mapDtoToSchedule = (dto: ScheduleItemDto): Schedule => {
+  const s = toLocalDateAndTime(dto.startTime);
+  const e = toLocalDateAndTime(dto.endTime);
+  return {
+    id: dto.id,
+    title: dto.title,
+    date: s.date,
+    startTime: s.time,
+    endTime: e.time,
+    type: "activity",
+    availableMembers: dto.attending.sample.map(m => m.displayName),
+    totalAttendeeCount: dto.attending.count,
+    isMine: dto.attending.isMine,
+  };
+};
+
+/** ===== API ===== */
+async function apiList(groupId: string, fromIso: string, toIso: string) {
+  return get<ScheduleItemDto[]>(`/groups/${groupId}/schedules`, { from: fromIso, to: toIso });
+}
+async function apiCreate(groupId: string, body: CreateReqDto) {
+  return post<{ id: number; overlappedIds: number[] }>(`/groups/${groupId}/schedules`, body);
+}
+async function apiUpdate(groupId: string, scheduleId: number, body: UpdateReqDto) {
+  return put<{ id: number; overlappedIds: number[] }>(`/groups/${groupId}/schedules/${scheduleId}`, body);
+}
+async function apiDelete(groupId: string, scheduleId: number) {
+  return del<void>(`/groups/${groupId}/schedules/${scheduleId}`);
+}
+async function apiAttendance(scheduleId: number, status: "GOING" | "NOT_GOING" | "TENTATIVE") {
+  return put<void>(`/schedules/${scheduleId}/attendance`, { status });
+}
+
+/** ===== 컴포넌트 ===== */
 const GroupCalendar = ({ groupId }: GroupCalendarProps) => {
+  const { toast } = useToast();
+
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(new Date());
-  const [schedules, setSchedules] = useState<Schedule[]>(mockSchedules);
+  const [schedules, setSchedules] = useState<Schedule[]>([]);
   const [isAddingSchedule, setIsAddingSchedule] = useState(false);
 
   // 신규 일정 폼
@@ -84,15 +137,10 @@ const GroupCalendar = ({ groupId }: GroupCalendarProps) => {
     title: "",
     startTime: "",
     endTime: "",
-    type: "activity" as ScheduleType | string
+    type: "activity" as ScheduleType | string,
   });
 
-  // 추천(자동완성)
-  const [recoLoading, setRecoLoading] = useState(false);
-  const [recoShown, setRecoShown] = useState(false);
-  const [recommendations, setRecommendations] = useState<RecommendedSchedule[]>([]);
-
-  // 편집/삭제 상태
+  // 수정 다이얼로그
   const [editOpen, setEditOpen] = useState(false);
   const [editing, setEditing] = useState<Schedule | null>(null);
   const [editForm, setEditForm] = useState({
@@ -100,9 +148,62 @@ const GroupCalendar = ({ groupId }: GroupCalendarProps) => {
     date: "",
     startTime: "",
     endTime: "",
-    type: "activity" as ScheduleType | string
+    // location/description을 폼에 넣고 싶다면 여기에 필드 추가
   });
 
+  // 선택 날짜의 하루 범위 조회
+  const reloadDay = async (day: Date) => {
+    const list = await apiList(groupId, startOfDayISO(day), endOfDayISO(day));
+    setSchedules(list.map(mapDtoToSchedule));
+  };
+
+  useEffect(() => {
+    if (!selectedDate) return;
+    (async () => {
+      try {
+        await reloadDay(selectedDate);
+      } catch (e) {
+        console.error(e);
+        toast({
+          title: "일정 조회 실패",
+          description: "일정을 불러오는 중 오류가 발생했습니다.",
+          variant: "destructive",
+        });
+        setSchedules([]);
+      }
+    })();
+  }, [groupId, selectedDate, toast]);
+
+  // 신규 생성
+  const handleAddSchedule = async () => {
+    if (!selectedDate) return;
+    if (!(newSchedule.title && newSchedule.startTime && newSchedule.endTime)) {
+      toast({ title: "입력을 확인해주세요", description: "제목/시간은 필수입니다.", variant: "destructive" });
+      return;
+    }
+
+    const [sh, sm] = newSchedule.startTime.split(":").map(Number);
+    const [eh, em] = newSchedule.endTime.split(":").map(Number);
+    const startIso = toIsoWithOffset(selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate(), sh, sm ?? 0, 0, 0);
+    const endIso   = toIsoWithOffset(selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate(), eh, em ?? 0, 0, 0);
+
+    try {
+      await apiCreate(groupId, { title: newSchedule.title.trim(), startTime: startIso, endTime: endIso });
+      await reloadDay(selectedDate);
+      setNewSchedule({ title: "", startTime: "", endTime: "", type: "activity" });
+      setIsAddingSchedule(false);
+      toast({ title: "일정이 추가되었습니다." });
+    } catch (e: any) {
+      console.error(e);
+      toast({
+        title: "일정 추가 실패",
+        description: typeof e?.message === "string" ? e.message : "오류가 발생했습니다.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  // 수정 다이얼로그 열기
   const openEdit = (s: Schedule) => {
     setEditing(s);
     setEditForm({
@@ -110,113 +211,96 @@ const GroupCalendar = ({ groupId }: GroupCalendarProps) => {
       date: toYmd(s.date),
       startTime: s.startTime,
       endTime: s.endTime,
-      type: s.type
     });
     setEditOpen(true);
   };
 
-  const saveEdit = () => {
-    if (!editing) return;
-    if (!editForm.title || !editForm.date || !editForm.startTime || !editForm.endTime) return;
+  // 수정 저장 → PUT
+  const handleSaveEdit = async () => {
+    if (!editing || !selectedDate) return;
 
-    setSchedules(prev =>
-        prev.map(s =>
-            s.id === editing.id
-                ? {
-                  ...s,
-                  title: editForm.title,
-                  date: fromYmd(editForm.date),
-                  startTime: editForm.startTime,
-                  endTime: editForm.endTime,
-                  type: editForm.type
-                }
-                : s
-        )
-    );
-    setEditOpen(false);
-    setEditing(null);
-  };
+    // 보낸 필드만 갱신되게 구성 (부분수정)
+    const body: UpdateReqDto = {};
+    if (editForm.title && editForm.title !== editing.title) body.title = editForm.title.trim();
 
-  const deleteSchedule = (id: string) => {
-    if (!confirm("이 일정을 삭제할까요?")) return;
-    setSchedules(prev => prev.filter(s => s.id !== id));
-  };
+    // 날짜/시간이 바뀌었으면 ISO 재조합
+    if (editForm.date && editForm.startTime) {
+      const d = new Date(editForm.date);
+      const [sh, sm] = editForm.startTime.split(":").map(Number);
+      body.startTime = toIsoWithOffset(d.getFullYear(), d.getMonth(), d.getDate(), sh, sm ?? 0, 0, 0);
+    }
+    if (editForm.date && editForm.endTime) {
+      const d = new Date(editForm.date);
+      const [eh, em] = editForm.endTime.split(":").map(Number);
+      body.endTime = toIsoWithOffset(d.getFullYear(), d.getMonth(), d.getDate(), eh, em ?? 0, 0, 0);
+    }
 
-  // 추가
-  const handleAddSchedule = () => {
-    if (selectedDate && newSchedule.title && newSchedule.startTime && newSchedule.endTime) {
-      const schedule: Schedule = {
-        id: Date.now().toString(),
-        title: newSchedule.title,
-        date: selectedDate,
-        startTime: newSchedule.startTime,
-        endTime: newSchedule.endTime,
-        type: newSchedule.type,
-        availableMembers: ["김민수"],
-        allMembers: allGroupMembers
-      };
-      setSchedules(prev => [...prev, schedule]);
-      setNewSchedule({ title: "", startTime: "", endTime: "", type: "activity" });
-      setRecommendations([]);
-      setRecoShown(false);
-      setIsAddingSchedule(false);
+    try {
+      await apiUpdate(groupId, editing.id, body);
+      await reloadDay(new Date(editForm.date || editing.date));
+      setEditOpen(false);
+      setEditing(null);
+      toast({ title: "일정이 수정되었습니다." });
+    } catch (e: any) {
+      console.error(e);
+      toast({
+        title: "일정 수정 실패",
+        description: typeof e?.message === "string" ? e.message : "오류가 발생했습니다.",
+        variant: "destructive",
+      });
     }
   };
 
-  const toggleParticipation = (scheduleId: string) => {
-    setSchedules(prev =>
-        prev.map(schedule => {
-          if (schedule.id === scheduleId) {
-            const isParticipating = schedule.availableMembers.includes("김민수");
-            return {
-              ...schedule,
-              availableMembers: isParticipating
-                  ? schedule.availableMembers.filter(member => member !== "김민수")
-                  : [...schedule.availableMembers, "김민수"]
-            };
-          }
-          return schedule;
-        })
-    );
+  // 삭제 → DELETE
+  const handleDelete = async (id: number) => {
+    if (!selectedDate) return;
+    if (!confirm("이 일정을 삭제할까요?")) return;
+    try {
+      await apiDelete(groupId, id);
+      await reloadDay(selectedDate);
+      toast({ title: "일정이 삭제되었습니다." });
+    } catch (e: any) {
+      console.error(e);
+      toast({
+        title: "일정 삭제 실패",
+        description: typeof e?.message === "string" ? e.message : "오류가 발생했습니다.",
+        variant: "destructive",
+      });
+    }
   };
 
-  const selectedDateSchedules = schedules.filter(
-      schedule => selectedDate && schedule.date.toDateString() === selectedDate.toDateString()
+  // 참여 토글 → PUT /attendance
+  const toggleParticipation = async (schedule: Schedule) => {
+    if (!selectedDate) return;
+    const next = schedule.isMine ? "NOT_GOING" : "GOING" as const;
+    try {
+      await apiAttendance(schedule.id, next);
+      await reloadDay(selectedDate);
+      toast({ title: next === "GOING" ? "참여로 표시했습니다." : "참여 해제했습니다." });
+    } catch (e: any) {
+      console.error(e);
+      toast({
+        title: "참여 상태 변경 실패",
+        description: typeof e?.message === "string" ? e.message : "오류가 발생했습니다.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  // 선택일 카드 목록
+  const selectedDateSchedules = useMemo(
+      () => schedules.filter(s => selectedDate && s.date.toDateString() === selectedDate.toDateString()),
+      [schedules, selectedDate]
   );
 
   const getTypeColor = (type: string) => {
     switch (type) {
-      case "arrival":
-        return "bg-green-500";
-      case "activity":
-        return "bg-blue-500";
-      case "departure":
-        return "bg-red-500";
-      default:
-        return "bg-gray-500";
+      case "arrival": return "bg-green-500";
+      case "activity": return "bg-blue-500";
+      case "departure": return "bg-red-500";
+      default: return "bg-gray-500";
     }
   };
-
-  // (Mock) 추천 가져오기
-  const fetchRecommendations = async () => {
-    setRecoLoading(true);
-    try {
-      const demo: RecommendedSchedule[] = [
-        { title: "성산일출봉 일출", startTime: "05:40", endTime: "07:30", type: "activity", source: "popular", score: 0.92 },
-        { title: "섭지코지 산책", startTime: "08:30", endTime: "09:30", type: "activity", source: "popular", score: 0.86 },
-        { title: "우도 일주 드라이브", startTime: "10:00", endTime: "12:00", type: "activity", source: "popular", score: 0.88 },
-        { title: "제주민속촌 관람", startTime: "13:30", endTime: "15:00", type: "activity", source: "recent", score: 0.81 },
-        { title: "애월 카페 투어", startTime: "15:30", endTime: "17:30", type: "activity", source: "popular", score: 0.9 },
-        { title: "숙소 체크인", startTime: "16:00", endTime: "16:30", type: "arrival", source: "recent", score: 0.81 }
-      ];
-      setRecommendations(demo);
-      setRecoShown(true);
-    } finally {
-      setRecoLoading(false);
-    }
-  };
-
-  // (지역별 그룹핑 제거됨)
 
   return (
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -229,15 +313,12 @@ const GroupCalendar = ({ groupId }: GroupCalendarProps) => {
                 <CalendarIcon className="h-5 w-5" />
                 <span>일정 캘린더</span>
               </span>
+
                 <Dialog
                     open={isAddingSchedule}
                     onOpenChange={(o) => {
                       setIsAddingSchedule(o);
-                      if (!o) {
-                        setRecommendations([]);
-                        setRecoShown(false);
-                        setRecoLoading(false);
-                      }
+                      if (!o) setNewSchedule({ title: "", startTime: "", endTime: "", type: "activity" });
                     }}
                 >
                   <DialogTrigger asChild>
@@ -250,8 +331,8 @@ const GroupCalendar = ({ groupId }: GroupCalendarProps) => {
                     <DialogHeader>
                       <DialogTitle>새 일정 추가</DialogTitle>
                     </DialogHeader>
+
                     <div className="space-y-4">
-                      {/* 기본 입력 */}
                       <div>
                         <Label htmlFor="title">일정 제목</Label>
                         <Input
@@ -261,6 +342,7 @@ const GroupCalendar = ({ groupId }: GroupCalendarProps) => {
                             placeholder="일정 제목을 입력하세요"
                         />
                       </div>
+
                       <div className="grid grid-cols-2 gap-4">
                         <div>
                           <Label htmlFor="startTime">시작 시간</Label>
@@ -282,47 +364,6 @@ const GroupCalendar = ({ groupId }: GroupCalendarProps) => {
                         </div>
                       </div>
 
-                      {/* 자동 완성 */}
-                      <Button
-                          type="button"
-                          variant="outline"
-                          className="w-full"
-                          onClick={fetchRecommendations}
-                          disabled={recoLoading}
-                      >
-                        {recoLoading ? "추천 불러오는 중..." : "✨ 자동 완성 (추천 일정 불러오기)"}
-                      </Button>
-
-                      {/* 추천 목록 (스크롤) */}
-                      {recoShown && (
-                        <div className="space-y-2 max-h-64 overflow-y-auto pr-2">
-                          {recommendations.map((r, idx) => (
-                            <div key={idx} className="flex items-center justify-between rounded-md border p-3">
-                              <div>
-                                <div className="font-medium">{r.title}</div>
-                                <div className="text-xs text-muted-foreground">
-                                  {r.startTime} - {r.endTime} • {r.type === "activity" ? "활동" : r.type === "arrival" ? "도착" : "출발"}
-                                  {typeof r.score === "number" ? ` • 유사도 ${(r.score * 100).toFixed(0)}%` : ""}
-                                </div>
-                              </div>
-                              <Button
-                                size="sm"
-                                onClick={() =>
-                                  setNewSchedule({
-                                    title: r.title,
-                                    startTime: r.startTime,
-                                    endTime: r.endTime,
-                                    type: r.type
-                                  })
-                                }
-                              >
-                                적용
-                              </Button>
-                            </div>
-                          ))}
-                        </div>
-                      )}
-
                       <div className="flex space-x-2">
                         <Button onClick={handleAddSchedule} className="flex-1">추가</Button>
                         <Button variant="outline" onClick={() => setIsAddingSchedule(false)} className="flex-1">취소</Button>
@@ -332,6 +373,7 @@ const GroupCalendar = ({ groupId }: GroupCalendarProps) => {
                 </Dialog>
               </CardTitle>
             </CardHeader>
+
             <CardContent>
               <Calendar
                   mode="single"
@@ -359,15 +401,15 @@ const GroupCalendar = ({ groupId }: GroupCalendarProps) => {
               </span>
               </CardTitle>
             </CardHeader>
+
             <CardContent>
               {selectedDateSchedules.length === 0 ? (
                   <p className="text-muted-foreground text-center py-8">선택된 날짜에 일정이 없습니다.</p>
               ) : (
                   <div className="space-y-4">
                     {selectedDateSchedules.map((schedule) => {
-                      const isParticipating = schedule.availableMembers.includes("김민수");
-                      const participantCount = schedule.availableMembers.length;
-                      const totalCount = schedule.allMembers.length;
+                      const isParticipating = schedule.isMine;
+                      const participantCount = schedule.totalAttendeeCount;
 
                       return (
                           <div key={schedule.id} className="border rounded-lg p-4">
@@ -385,7 +427,13 @@ const GroupCalendar = ({ groupId }: GroupCalendarProps) => {
                                 <Button variant="ghost" size="icon" onClick={() => openEdit(schedule)} title="수정">
                                   <Pencil className="h-4 w-4" />
                                 </Button>
-                                <Button variant="ghost" size="icon" className="text-red-500 hover:text-red-600" onClick={() => deleteSchedule(schedule.id)} title="삭제">
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="text-red-500 hover:text-red-600"
+                                    title="삭제"
+                                    onClick={() => handleDelete(schedule.id)}
+                                >
                                   <Trash2 className="h-4 w-4" />
                                 </Button>
                               </div>
@@ -394,13 +442,13 @@ const GroupCalendar = ({ groupId }: GroupCalendarProps) => {
                             <div className="flex items-center justify-between mb-3">
                               <div className="flex items-center space-x-2 text-sm text-muted-foreground">
                                 <Users className="h-4 w-4" />
-                                <span>{participantCount}/{totalCount} 참여</span>
+                                <span>{participantCount}명 참여</span>
                               </div>
                               <div className="flex items-center space-x-2">
                                 <Checkbox
                                     id={`participate-${schedule.id}`}
                                     checked={isParticipating}
-                                    onCheckedChange={() => toggleParticipation(schedule.id)}
+                                    onCheckedChange={() => toggleParticipation(schedule)}
                                 />
                                 <Label htmlFor={`participate-${schedule.id}`} className="text-sm cursor-pointer">
                                   참여하기
@@ -420,7 +468,7 @@ const GroupCalendar = ({ groupId }: GroupCalendarProps) => {
           </Card>
         </div>
 
-        {/* ✏️ 일정 수정 다이얼로그 */}
+        {/* ✏️ 수정 다이얼로그 */}
         <Dialog open={editOpen} onOpenChange={(o) => { setEditOpen(o); if (!o) setEditing(null); }}>
           <DialogContent>
             <DialogHeader>
@@ -464,22 +512,8 @@ const GroupCalendar = ({ groupId }: GroupCalendarProps) => {
                   />
                 </div>
               </div>
-              {/* 필요시 종류 선택 UI 추가 가능 */}
-              {/* <div>
-              <Label htmlFor="edit-type">종류</Label>
-              <select
-                id="edit-type"
-                className="w-full p-2 border border-input rounded-md bg-background"
-                value={editForm.type}
-                onChange={(e) => setEditForm(f => ({ ...f, type: e.target.value }))}
-              >
-                <option value="activity">활동</option>
-                <option value="arrival">도착</option>
-                <option value="departure">출발</option>
-              </select>
-            </div> */}
               <div className="flex gap-2">
-                <Button className="flex-1" onClick={saveEdit}>저장</Button>
+                <Button className="flex-1" onClick={handleSaveEdit}>저장</Button>
                 <Button variant="outline" className="flex-1" onClick={() => setEditOpen(false)}>취소</Button>
               </div>
             </div>

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -6,3 +6,71 @@ export const http = axios.create({
     withCredentials: true,   // ✅ 쿠키 포함
     headers: { "Content-Type": "application/json" },
 });
+
+// --- 요청 인터셉터 ---
+http.interceptors.request.use(
+    (config) => {
+        // 필요 시 여기에 로직 추가 (e.g. 토큰 헤더)
+        return config;
+    },
+    (error) => Promise.reject(error),
+);
+
+// --- 응답 인터셉터 ---
+http.interceptors.response.use(
+    (response) => response,
+    (error) => {
+        // 401: Unauthorized (인증 실패)
+        if (error.response?.status === 401) {
+            // 예: 로그인 페이지로 리다이렉트
+            // window.location.href = "/auth/login";
+        }
+        // 419: Authentication Timeout (CSRF 토큰 만료 등)
+        else if (error.response?.status === 419) {
+            // 예: 페이지 새로고침 또는 재인증 요청
+            // window.location.reload();
+        }
+        return Promise.reject(error);
+    },
+);
+
+// --- API 함수들 ---
+
+/**
+ * GET 요청
+ * @param url - 요청할 URL
+ * @param params - 쿼리 파라미터
+ */
+export const get = async <T>(url: string, params?: object): Promise<T> => {
+    const response = await http.get<T>(url, { params });
+    return response.data;
+};
+
+/**
+ * POST 요청
+ * @param url - 요청할 URL
+ * @param data - 전송할 데이터
+ */
+export const post = async <T>(url: string, data: object): Promise<T> => {
+    const response = await http.post<T>(url, data);
+    return response.data;
+};
+
+/**
+ * PUT 요청
+ * @param url - 요청할 URL
+ * @param data - 전송할 데이터
+ */
+export const put = async <T>(url: string, data: object): Promise<T> => {
+    const response = await http.put<T>(url, data);
+    return response.data;
+};
+
+/**
+ * DELETE 요청
+ * @param url - 요청할 URL
+ */
+export const del = async <T>(url: string): Promise<T> => {
+    const response = await http.delete<T>(url);
+    return response.data;
+};


### PR DESCRIPTION
## 📌 PR 목적
GroupCalendar에 일정 CRUD + 참여 토글 연동

## ✨ 변경 사항
- `src/components/GroupCalendar.tsx`
  - `GET /groups/{groupId}/schedules?from&to` 연동 (하루 범위)
  - `POST /groups/{groupId}/schedules` 연동 (명시적 오프셋 ISO)
  - `PUT /groups/{groupId}/schedules/{scheduleId}` 연동 (부분수정)
  - `DELETE /groups/{groupId}/schedules/{scheduleId}` 연동
  - `PUT /schedules/{scheduleId}/attendance` 연동(낙관적 갱신)
  - 타임존 보정 유틸: `toIsoWithOffset`, `startOfDayISO`, `endOfDayISO`
  - 토스트로 오류/성공 피드백

- `src/lib/http.ts`
  - Authorization: `Bearer ${localStorage.getItem("accessToken")}` 자동 포함

## 🔗 이슈
Closes #13 