### PR TITLE
feat(profile): 마이페이지 최소화 및 /api/auth/me 연동

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,194 +1,202 @@
-
-import { useState, useEffect } from "react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
-import { ArrowLeft, User, Calendar, Edit, LogOut } from "lucide-react";
+import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { ArrowLeft, LogOut, Save, X, User } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useAuth } from "@/hooks/useAuth";
-import ProfileEditDialog from "@/components/ProfileEditDialog";
 import { useToast } from "@/hooks/use-toast";
 
-interface UserProfile {
+interface ProfileData {
+  id: number;
+  username: string;
   name: string;
+  nickname?: string;
   email: string;
-  bio: string;
-  join_date: string;
-  avatar_url?: string;
 }
 
 const Profile = () => {
   const { user, signOut } = useAuth();
-  const navigate = useNavigate();
   const { toast } = useToast();
-  const [profile, setProfile] = useState<UserProfile | null>(null);
-  const [profileEditOpen, setProfileEditOpen] = useState(false);
-  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
 
-  const [recentTrips] = useState([
-    {
-      id: '1',
-      name: '제주도 여행',
-      status: '진행 중',
-      participants: 4,
-      dates: '2024.04.15-17'
-    },
-    {
-      id: '2',
-      name: '부산 여행',
-      status: '완료',
-      participants: 3,
-      dates: '2024.03.08-10'
-    },
-    {
-      id: '3',
-      name: '강릉 여행',
-      status: '완료',
-      participants: 5,
-      dates: '2024.02.20-22'
-    }
-  ]);
+  const [profile, setProfile] = useState<ProfileData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [name, setName] = useState("");
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
-    if (user) {
-      fetchProfile();
+    if (!user) {
+      navigate("/auth");
     } else {
-      navigate('/auth');
+      loadProfile();
     }
-  }, [user, navigate]);
+  }, [user]);
 
-  const fetchProfile = async () => {
-    if (!user) return;
-
+  /** 프로필 조회 API */
+  const loadProfile = async () => {
     setLoading(true);
-    
-    // TODO: Replace with your backend API call
-    // Mock profile data
-    setProfile({
-      name: user.name || '사용자',
-      email: user.email || '',
-      bio: '여행을 사랑하는 사용자입니다.',
-      join_date: '2024년 1월',
-      avatar_url: ''
-    });
-    
-    setLoading(false);
+    try {
+      const res = await fetch("/api/auth/me", {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+        },
+      });
+      if (!res.ok) throw new Error("불러오기 실패");
+      const data: ProfileData = await res.json();
+      setProfile(data);
+      setName(data.name);
+      setDirty(false);
+    } catch (err) {
+      toast({
+        title: "불러오기 실패",
+        description: "프로필 정보를 가져올 수 없습니다.",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  /** 이름 저장 API */
+  const handleSave = async () => {
+    if (!profile) return;
+    try {
+      setSaving(true);
+      const res = await fetch("/api/auth/me", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+        },
+        body: JSON.stringify({ name }),
+      });
+      if (!res.ok) throw new Error("저장 실패");
+
+      const updated: ProfileData = await res.json();
+      setProfile(updated);
+      setName(updated.name);
+      setDirty(false);
+
+      toast({
+        title: "저장 완료",
+        description: "이름이 업데이트되었습니다.",
+      });
+    } catch (e) {
+      toast({
+        title: "저장 실패",
+        description: "입력값 검증 또는 네트워크 오류",
+        variant: "destructive",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    if (profile) setName(profile.name);
+    setDirty(false);
   };
 
   const handleLogout = async () => {
     await signOut();
-    toast({
-      title: "로그아웃",
-      description: "성공적으로 로그아웃되었습니다.",
-    });
-    navigate('/');
-  };
-
-  const getStatusBadge = (status: string) => {
-    switch (status) {
-      case '진행 중':
-        return <Badge variant="default">진행 중</Badge>;
-      case '완료':
-        return <Badge variant="secondary">완료</Badge>;
-      default:
-        return <Badge variant="outline">{status}</Badge>;
-    }
+    toast({ title: "로그아웃", description: "성공적으로 로그아웃되었습니다." });
+    navigate("/");
   };
 
   if (loading) {
-    return <div className="min-h-screen bg-background flex items-center justify-center">로딩 중...</div>;
+    return <div className="min-h-screen flex items-center justify-center">로딩 중...</div>;
   }
 
   if (!profile) {
-    return <div className="min-h-screen bg-background flex items-center justify-center">프로필을 불러올 수 없습니다.</div>;
+    return <div className="min-h-screen flex items-center justify-center">프로필을 불러올 수 없습니다.</div>;
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      {/* Header */}
-      <div className="sticky top-0 z-40 border-b bg-card/80 backdrop-blur-md">
-        <div className="container mx-auto px-4 h-16 flex items-center justify-between">
-          <div className="flex items-center space-x-4">
-            <Link to="/">
-              <Button variant="ghost" size="icon">
-                <ArrowLeft className="h-5 w-5" />
-              </Button>
-            </Link>
-            <div className="flex items-center space-x-2">
-              <User className="h-6 w-6 text-primary" />
-              <h1 className="text-xl font-bold text-foreground">마이페이지</h1>
+      <div className="min-h-screen bg-background">
+        {/* Header */}
+        <div className="sticky top-0 z-40 border-b bg-card/80 backdrop-blur-md">
+          <div className="container mx-auto px-4 h-16 flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <Link to="/">
+                <Button variant="ghost" size="icon">
+                  <ArrowLeft className="h-5 w-5" />
+                </Button>
+              </Link>
+              <div className="flex items-center gap-2">
+                <User className="h-6 w-6 text-primary" />
+                <h1 className="text-xl font-bold text-foreground">마이페이지</h1>
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      {/* Content */}
-      <div className="container mx-auto px-4 py-6">
-        <div className="max-w-4xl mx-auto space-y-6">
-          {/* Profile Card */}
-          <Card>
-            <CardHeader>
-              <div className="flex items-start justify-between">
-                <div className="flex items-center space-x-4">
-                  <Avatar className="h-20 w-20">
-                    <AvatarImage
-                      key={profile.avatar_url || 'no-avatar'}
-                      src={profile.avatar_url ? `${profile.avatar_url}` : undefined}
-                      alt={profile.name}
-                      onError={(e) => {
-                        (e.currentTarget as HTMLImageElement).src = '';
-                      }}
+        {/* Content */}
+        <div className="container mx-auto px-4 py-6">
+          <div className="max-w-md mx-auto space-y-6">
+            {/* Profile */}
+            <Card>
+              <CardHeader className="flex flex-col items-center gap-3">
+                <Avatar className="h-20 w-20">
+                  <AvatarImage src={undefined} alt={profile.name} />
+                  <AvatarFallback className="text-lg bg-primary/10 text-primary">
+                    {profile.name.substring(0, 1)}
+                  </AvatarFallback>
+                </Avatar>
+                <CardTitle>{profile.email}</CardTitle>
+                <CardDescription>내 프로필</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">이름</label>
+                  <div className="flex gap-2">
+                    <Input
+                        value={name}
+                        onChange={(e) => {
+                          setName(e.target.value);
+                          setDirty(e.target.value !== profile.name);
+                        }}
                     />
-                    <AvatarFallback className="text-lg bg-primary/10 text-primary">
-                      {profile.name.substring(0, 1)}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div>
-                    <CardTitle className="text-2xl text-foreground">{profile.name}</CardTitle>
-                    <CardDescription className="text-base">{profile.email}</CardDescription>
-                    <div className="flex items-center space-x-2 mt-2">
-                      <Calendar className="h-4 w-4 text-muted-foreground" />
-                      <span className="text-sm text-muted-foreground">{profile.join_date} 가입</span>
-                    </div>
+                    {dirty ? (
+                        <>
+                          <Button size="sm" onClick={handleSave} disabled={saving}>
+                            <Save className="h-4 w-4 mr-1" />
+                            저장
+                          </Button>
+                          <Button size="sm" variant="outline" onClick={handleCancel} disabled={saving}>
+                            <X className="h-4 w-4 mr-1" />
+                            취소
+                          </Button>
+                        </>
+                    ) : (
+                        <Button size="sm" variant="outline" disabled>
+                          변경 없음
+                        </Button>
+                    )}
                   </div>
                 </div>
-                <div className="flex items-center">
-                  <Button variant="secondary" size="sm" onClick={() => setProfileEditOpen(true)}>
-                    <Edit className="h-4 w-4 mr-2" />
-                    프로필 수정
-                  </Button>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground mb-4">{profile.bio}</p>
-            </CardContent>
-          </Card>
+              </CardContent>
+            </Card>
 
-          {/* Logout Button */}
-          <Card>
-            <CardContent className="pt-6">
-              <Button
-                variant="outline"
-                className="w-full justify-center h-12 text-destructive hover:text-destructive"
-                onClick={handleLogout}
-              >
-                <LogOut className="h-4 w-4 mr-3" />
-                로그아웃
-              </Button>
-            </CardContent>
-          </Card>
+            {/* Logout */}
+            <Card>
+              <CardContent className="pt-6">
+                <Button
+                    variant="outline"
+                    className="w-full justify-center h-12 text-destructive hover:text-destructive"
+                    onClick={handleLogout}
+                >
+                  <LogOut className="h-4 w-4 mr-3" />
+                  로그아웃
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
         </div>
       </div>
-
-      <ProfileEditDialog
-        open={profileEditOpen}
-        onOpenChange={setProfileEditOpen}
-        onProfileUpdate={fetchProfile}
-      />
-
-    </div>
   );
 };
 


### PR DESCRIPTION
### 📌 목적 (Why)
- MVP-6: 마이페이지 기능을 **이름 변경 + 로그아웃**으로 최소화하고,
- 백엔드 API(`/api/auth/me`)와 실제로 연동하여 배포 가능한 상태로 만든다.

---

### 🔧 변경 사항 (What)
- **페이지**: `Profile.tsx` 전면 수정
  - `GET /api/auth/me`로 프로필(name, email 등) 조회
  - `PUT /api/auth/me`로 이름 변경 저장
  - 상태 관리: `loading`, `dirty`, `saving`
  - 성공/실패 토스트 메시지 처리
- **UI 정리**
  - `ProfileEditDialog` 제거(인라인 입력/저장으로 단순화)
  - `recentTrips`/`bio`/`join_date` 등 비핵심 요소 제거
  - 아바타는 **원형 + 이니셜(AvatarFallback)** 유지
  - “변경 없음” 버튼으로 비활성 상태 명확화
- **보안/설정**
  - 요청 헤더에 `Authorization: Bearer <accessToken>` 적용
 

---

### 🔗 이슈 링크 (Related Issues)
- Parent: [#MVP-6](https://github.com/gatieottae/backend/issues/53) 
 