### PR TITLE
feat: 정산/지출 관리 API 연동

### DIFF
--- a/src/components/PaymentCalculator.tsx
+++ b/src/components/PaymentCalculator.tsx
@@ -1,4 +1,8 @@
-import { useState } from "react";
+// PaymentCalculator.tsx
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { get, post, del } from "@/lib/http";
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -6,22 +10,26 @@ import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { Calculator, Plus, Trash2, DollarSign, Check, X } from "lucide-react";
+import { Calculator, Trash2, DollarSign } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
+/** ===== Props & UI Types ===== */
 interface PaymentCalculatorProps {
   groupId: string;
   members: Array<{ id: string; name: string; avatar?: string }>;
+  currentUser: string; // 이름
 }
 
-interface Expense {
+type SplitType = "equal" | "custom";
+
+interface ExpenseUI {
   id: string;
   title: string;
-  amount: number;
-  paidBy: string;
-  splitAmong: string[];
-  date: string;
-  splitType: "equal" | "custom";
+  amount: number; // 원 단위 정수
+  paidBy: string; // 이름
+  splitAmong: string[]; // 이름 배열
+  date: string; // YYYY-MM-DD
+  splitType: SplitType;
   customSplits?: { [memberName: string]: number };
 }
 
@@ -33,248 +41,273 @@ interface PaymentStatus {
   received: boolean;
 }
 
-// 임시 결제 데이터
-const mockExpenses: Expense[] = [
-  {
-    id: "1",
-    title: "제주도 숙소 예약",
-    amount: 240000,
-    paidBy: "김민수",
-    splitAmong: ["김민수", "이지은", "박정우", "최유리"],
-    date: "2025-03-01",
-    splitType: "equal"
-  },
-  {
-    id: "2",
-    title: "렌터카 대여",
-    amount: 120000,
-    paidBy: "이지은",
-    splitAmong: ["김민수", "이지은", "박정우", "최유리"],
-    date: "2025-03-02",
-    splitType: "equal"
-  },
-  {
-    id: "3",
-    title: "저녁 식사",
-    amount: 40000,
-    paidBy: "김민수",
-    splitAmong: ["김민수", "박정우"],
-    date: "2025-03-03",
-    splitType: "equal"
-  },
-  {
-    id: "4",
-    title: "점심 식사",
-    amount: 20000,
-    paidBy: "박정우",
-    splitAmong: ["김민수", "박정우"],
-    date: "2025-03-04",
-    splitType: "equal"
-  }
-];
+/** ===== Server DTO (가정) ===== */
+interface ExpenseRes {
+  id: number;
+  title: string;
+  amount: number;          // BIGINT(원)
+  paidById: number;
+  paidAt: string;          // ISO
+  shares: Array<{ memberId: number; share: number }>;
+}
 
-// Add currentUser prop for 송금 상태 display logic
-const PaymentCalculator = ({ groupId, members, currentUser }: PaymentCalculatorProps & { currentUser: string }) => {
-  const [expenses, setExpenses] = useState<Expense[]>(mockExpenses);
+/** ===== API Calls ===== */
+const fetchExpenses = (groupId: string) =>
+    get<ExpenseRes[]>(`/groups/${groupId}/expenses`);
+
+const createExpense = (groupId: string, payload: any) =>
+    post<ExpenseRes>(`/groups/${groupId}/expenses`, payload);
+
+const deleteExpense = (groupId: string, expenseId: string | number) =>
+    del(`/groups/${groupId}/expenses/${expenseId}`);
+
+/** ===== Helpers ===== */
+const ymd = (iso?: string) =>
+    (iso ? new Date(iso) : new Date()).toISOString().split("T")[0];
+
+/** 균등 분배(원 단위) — 나머지는 앞에서부터 +1로 분배 */
+function makeEqualShares(amount: number, memberIds: number[]) {
+  const n = memberIds.length;
+  const base = Math.floor(amount / n);
+  let rem = amount % n;
+  return memberIds.map((id, idx) => ({
+    memberId: id,
+    share: base + (idx < rem ? 1 : 0),
+  }));
+}
+
+/** shares로부터 splitType 추론 (모두 동일 금액이면 equal) */
+function inferSplitType(shares: Array<{ memberId: number; share: number }>): SplitType {
+  if (shares.length <= 1) return "custom";
+  const first = shares[0].share;
+  return shares.every(s => s.share === first) ? "equal" : "custom";
+}
+
+/** 서버 → UI 매핑 */
+function mapExpenseToUI(e: ExpenseRes, nameById: (id: number) => string): ExpenseUI {
+  const splitType = inferSplitType(e.shares);
+  const splitAmong = e.shares.map(s => nameById(s.memberId)).filter(Boolean);
+  const customSplits =
+      splitType === "custom"
+          ? Object.fromEntries(e.shares.map(s => [nameById(s.memberId), s.share]))
+          : undefined;
+  return {
+    id: String(e.id),
+    title: e.title,
+    amount: e.amount,
+    paidBy: nameById(e.paidById),
+    splitAmong,
+    date: ymd(e.paidAt),
+    splitType,
+    customSplits,
+  };
+}
+
+const PaymentCalculator = ({ groupId, members, currentUser }: PaymentCalculatorProps) => {
+  /** ===== Member Mappings (id ↔ name) ===== */
+  const idByName = useMemo(() => {
+    const m = new Map<string, number>();
+    members.forEach(mem => m.set(mem.name, Number(mem.id)));
+    return m;
+  }, [members]);
+
+  const nameByIdFn = (id: number) => {
+    const found = members.find(m => Number(m.id) === id);
+    return found?.name ?? `#${id}`;
+  };
+
+  /** ===== Local UI State (폼/모달/송금 가짜상태) ===== */
   const [isAddingExpense, setIsAddingExpense] = useState(false);
-  const [paymentStatuses, setPaymentStatuses] = useState<PaymentStatus[]>([{ from: "박정우", to: "김민수", amount: 20000, sent: true, received: true }]);
-  const [newExpense, setNewExpense] = useState({
+  const [paymentStatuses, setPaymentStatuses] = useState<PaymentStatus[]>([
+    { from: "박정우", to: "김민수", amount: 20000, sent: true, received: true },
+  ]);
+
+  const [newExpense, setNewExpense] = useState<{
+    title: string;
+    amount: string; // 입력값 문자열
+    paidBy: string; // 이름
+    splitAmong: string[];
+    splitType: SplitType;
+    customSplits: { [memberName: string]: number };
+  }>({
     title: "",
     amount: "",
     paidBy: members[0]?.name || "",
     splitAmong: members.map(m => m.name),
-    splitType: "equal" as "equal" | "custom",
-    customSplits: {} as { [memberName: string]: number }
+    splitType: "equal",
+    customSplits: {},
   });
 
-  const handleAddExpense = () => {
-    if (newExpense.title && newExpense.amount && newExpense.paidBy) {
-      // Validation: 총 분담금 === 지출 금액
-      if (newExpense.splitType === "custom") {
-        const totalShares = Object.values(newExpense.customSplits).reduce((sum, amount) => sum + (amount || 0), 0);
-        if (totalShares !== Number(newExpense.amount)) {
-          alert("분담금 총합이 지출 금액과 일치하지 않습니다.");
-          return;
-        }
+  /** ===== React Query: expenses ===== */
+  const qc = useQueryClient();
+
+  const { data: expensesRes, isLoading, isError } = useQuery({
+    queryKey: ["expenses", groupId],
+    queryFn: () => fetchExpenses(groupId),
+    staleTime: 30_000,
+  });
+
+  const expenses: ExpenseUI[] = useMemo(() => {
+    if (!expensesRes) return [];
+    return expensesRes
+        .slice()
+        .sort((a, b) => (a.paidAt < b.paidAt ? 1 : -1)) // 최신순
+        .map(e => mapExpenseToUI(e, nameByIdFn));
+  }, [expensesRes]);
+
+  /** ===== Create ===== */
+  const { mutate: mutateCreate, isPending: creating } = useMutation({
+    mutationFn: async () => {
+      // --- 입력 검증 ---
+      const title = newExpense.title.trim();
+      if (!title) throw new Error("지출 내역을 입력하세요.");
+
+      const amount = Number(newExpense.amount);
+      if (!Number.isInteger(amount) || amount <= 0) {
+        throw new Error("금액을 올바르게 입력하세요. (정수, 1원 이상)");
       }
-      const expense: Expense = {
-        id: Date.now().toString(),
-        title: newExpense.title,
-        amount: parseInt(newExpense.amount),
-        paidBy: newExpense.paidBy,
-        splitAmong: newExpense.splitAmong,
-        date: new Date().toISOString().split('T')[0],
-        splitType: newExpense.splitType,
-        customSplits: newExpense.splitType === "custom" ? newExpense.customSplits : undefined
+
+      const paidById = idByName.get(newExpense.paidBy);
+      if (paidById == null) {
+        throw new Error("지불자를 선택하세요.");
+      }
+
+      const selectedIds = newExpense.splitAmong
+        .map((n) => idByName.get(n))
+        .filter((id): id is number => id != null);
+
+      if (selectedIds.length === 0) {
+        throw new Error("분담자를 1명 이상 선택하세요.");
+      }
+
+      // --- shares 생성 ---
+      let shares: Array<{ memberId: number; share: number }>;
+      if (newExpense.splitType === "equal") {
+        shares = makeEqualShares(amount, selectedIds);
+      } else {
+        const sum = selectedIds
+          .map((id) => newExpense.customSplits[nameByIdFn(id)] || 0)
+          .reduce((a, b) => a + b, 0);
+
+        if (sum !== amount) {
+          throw new Error("분담금 총합이 지출 금액과 일치하지 않습니다.");
+        }
+
+        shares = selectedIds.map((id) => ({
+          memberId: id,
+          share: newExpense.customSplits[nameByIdFn(id)] || 0,
+        }));
+      }
+
+      // --- 날짜 포맷: YYYY-MM-DDTHH:mm:ss ---
+      const paidAt = new Date().toISOString().split(".")[0];
+
+      // --- 서버 전송 페이로드 ---
+      const payload = {
+        title,
+        amount,
+        paidById,
+        paidAt,
+        shares,
       };
-      setExpenses([...expenses, expense]);
+
+      return createExpense(groupId, payload);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["expenses", groupId] });
+      setIsAddingExpense(false);
       setNewExpense({
         title: "",
         amount: "",
         paidBy: members[0]?.name || "",
         splitAmong: members.map(m => m.name),
         splitType: "equal",
-        customSplits: {}
+        customSplits: {},
       });
-      setIsAddingExpense(false);
-    }
-  };
+    },
+    onError: (e: any) => {
+      alert(e?.message ?? "지출 추가 중 오류가 발생했습니다.");
+    },
+  });
 
-  const handleDeleteExpense = (expenseId: string) => {
-    setExpenses(expenses.filter(exp => exp.id !== expenseId));
-  };
+  /** ===== Delete ===== */
+  const { mutate: mutateDelete } = useMutation({
+    mutationFn: (expenseId: string) => deleteExpense(groupId, expenseId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["expenses", groupId] }),
+    onError: (e: any) => alert(e?.message ?? "삭제 중 오류가 발생했습니다."),
+  });
 
-  const toggleMemberInSplit = (memberName: string) => {
-    setNewExpense({
-      ...newExpense,
-      splitAmong: newExpense.splitAmong.includes(memberName)
-        ? newExpense.splitAmong.filter(name => name !== memberName)
-        : [...newExpense.splitAmong, memberName]
-    });
-  };
-
-  const handleCustomSplitChange = (memberName: string, amount: string) => {
-    setNewExpense({
-      ...newExpense,
-      customSplits: {
-        ...newExpense.customSplits,
-        [memberName]: parseFloat(amount) || 0
-      }
-    });
-  };
-
+  /** ===== 기존 송금 UI 가짜로 유지 (다음 단계에 API/WS 연결) ===== */
   const togglePaymentSent = (from: string, to: string, amount: number) => {
-    const key = `${from}-${to}`;
     setPaymentStatuses(prev => {
       const existing = prev.find(p => p.from === from && p.to === to);
       if (existing) {
-        return prev.map(p =>
-          p.from === from && p.to === to
-            ? { ...p, sent: !p.sent }
-            : p
-        );
+        return prev.map(p => (p.from === from && p.to === to ? { ...p, sent: !p.sent } : p));
       } else {
         return [...prev, { from, to, amount, sent: true, received: false }];
       }
     });
   };
+  const getPaymentStatus = (from: string, to: string) =>
+      paymentStatuses.find(p => p.from === from && p.to === to);
 
-  const togglePaymentReceived = (from: string, to: string, amount: number) => {
-    const key = `${from}-${to}`;
-    setPaymentStatuses(prev => {
-      const existing = prev.find(p => p.from === from && p.to === to);
-      if (existing) {
-        return prev.map(p =>
-          p.from === from && p.to === to
-            ? { ...p, received: !p.received }
-            : p
-        );
-      } else {
-        return [...prev, { from, to, amount, sent: false, received: true }];
-      }
-    });
-  };
+  /** ===== 기존 계산 로직은 UI용으로 유지 (서버 연동 전 임시) ===== */
+  const formatCurrency = (amount: number) =>
+      new Intl.NumberFormat("ko-KR").format(amount) + "원";
 
-  const getPaymentStatus = (from: string, to: string) => {
-    return paymentStatuses.find(p => p.from === from && p.to === to);
-  };
-
-  // ---- MOCK 송금 상태 예시 UI ----
-  // This is mock UI logic for payment state simulation
-  // 상태: "initial", "toSend", "waitingConfirm", "confirmed", "cancelled"
-  // a: currentUser, b: 상대방
-  // 화면 예시를 아래 컴포넌트에서 하드코딩 렌더링합니다.
-  type PaymentMockState = "initial" | "toSend" | "waitingConfirm" | "confirmed" | "cancelled";
-  // a가 currentUser, b가 "이지은"이라고 가정
-  const a = currentUser;
-  const b = "이지은";
-  // 상태 예시: 바꿔가며 확인할 수 있음
-  const exampleStates: PaymentMockState[] = [
-    "initial", "toSend", "waitingConfirm", "confirmed", "cancelled"
-  ];
-  // 실제로는 아래 state를 바꿔가며 UI를 확인
-  const state: PaymentMockState = "initial"; // <- 여기서 상태를 바꿔 테스트
-
-  // 정산 계산
   const calculateSettlement = () => {
     const memberBalances: { [key: string]: number } = {};
-
-    // 멤버별 잔액 초기화
-    members.forEach(member => {
-      memberBalances[member.name] = 0;
-    });
-
-    // 각 지출에 대해 계산
-    expenses.forEach(expense => {
-      if (expense.splitType === "equal") {
-        const splitAmount = expense.amount / expense.splitAmong.length;
-
-        // 지불자는 전액 지불했으므로 플러스
-        memberBalances[expense.paidBy] += expense.amount;
-
-        // 분담자들은 각자 분담금만큼 마이너스
-        expense.splitAmong.forEach(member => {
-          memberBalances[member] -= splitAmount;
+    members.forEach(m => (memberBalances[m.name] = 0));
+    expenses.forEach(exp => {
+      if (exp.splitType === "equal") {
+        const splitAmount = Math.floor(exp.amount / exp.splitAmong.length);
+        let rem = exp.amount % exp.splitAmong.length;
+        memberBalances[exp.paidBy] += exp.amount;
+        exp.splitAmong.forEach((name, idx) => {
+          const a = splitAmount + (idx < rem ? 1 : 0);
+          memberBalances[name] -= a;
         });
-      } else if (expense.splitType === "custom" && expense.customSplits) {
-        // 지불자는 전액 지불했으므로 플러스
-        memberBalances[expense.paidBy] += expense.amount;
-
-        // 분담자들은 각자 설정된 금액만큼 마이너스
-        Object.entries(expense.customSplits).forEach(([member, amount]) => {
-          memberBalances[member] -= amount;
+      } else if (exp.customSplits) {
+        memberBalances[exp.paidBy] += exp.amount;
+        Object.entries(exp.customSplits).forEach(([name, a]) => {
+          memberBalances[name] -= a;
         });
       }
     });
-
     return memberBalances;
   };
 
   const calculateTransfers = () => {
     const balances = calculateSettlement();
-    console.log("Member Balances:", balances); // Debug log
     const transfers: { from: string; to: string; amount: number }[] = [];
-
-    const debtors = Object.entries(balances).filter(([_, balance]) => balance < 0);
-    const creditors = Object.entries(balances).filter(([_, balance]) => balance > 0);
-
+    const debtors = Object.entries(balances).filter(([_, b]) => b < 0);
+    const creditors = Object.entries(balances).filter(([_, b]) => b > 0);
     debtors.forEach(([debtor, debt]) => {
       creditors.forEach(([creditor, credit]) => {
         if (Math.abs(debt) > 0 && credit > 0) {
-          const transferAmount = Math.min(Math.abs(debt), credit);
-          transfers.push({
-            from: debtor,
-            to: creditor,
-            amount: Math.round(transferAmount)
-          });
-
-          balances[debtor] += transferAmount;
-          balances[creditor] -= transferAmount;
+          const t = Math.min(Math.abs(debt), credit);
+          transfers.push({ from: debtor, to: creditor, amount: Math.round(t) });
+          balances[debtor] += t;
+          balances[creditor] -= t;
         }
       });
     });
-
     return transfers.filter(t => t.amount > 0);
   };
 
   const balances = calculateSettlement();
   const transfers = calculateTransfers();
-  const totalExpenses = expenses.reduce((sum, exp) => sum + exp.amount, 0);
+  const totalExpenses = expenses.reduce((sum, e) => sum + e.amount, 0);
 
-  // Categorize transfers for the current user
   const myTransfersToReceive = transfers.filter(
-    (t) => t.to === currentUser && !(getPaymentStatus(t.from, t.to)?.received)
+      t => t.to === currentUser && !(getPaymentStatus(t.from, t.to)?.received),
   );
   const myTransfersToSend = transfers.filter(
-    (t) => t.from === currentUser && !(getPaymentStatus(t.from, t.to)?.sent)
+      t => t.from === currentUser && !(getPaymentStatus(t.from, t.to)?.sent),
   );
   const completedTransfers = transfers.filter(
-    (t) => (getPaymentStatus(t.from, t.to)?.sent) && (getPaymentStatus(t.from, t.to)?.received)
+      t => getPaymentStatus(t.from, t.to)?.sent && getPaymentStatus(t.from, t.to)?.received,
   );
-
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat('ko-KR').format(amount) + '원';
-  };
 
   const getTransferStatusText = (from: string, to: string) => {
     const status = getPaymentStatus(from, to);
@@ -282,408 +315,250 @@ const PaymentCalculator = ({ groupId, members, currentUser }: PaymentCalculatorP
     if (status?.sent && !status?.received) return `${from}님 → 송금 완료 (확인 대기)`;
     return `${from}님 → 아직 송금 안함`;
   };
+
+  /** ===== Render ===== */
   return (
-    <div>
-      <Tabs defaultValue="my-settlement" className="w-full">
-        <TabsList className="grid w-full grid-cols-3">
-          <TabsTrigger value="history">지출 내역</TabsTrigger>
-          <TabsTrigger value="my-settlement">나의 정산</TabsTrigger>
-          <TabsTrigger value="overall-settlement">전체 정산 현황</TabsTrigger>
-        </TabsList>
+      <div>
+        <Tabs defaultValue="history" className="w-full">
+          <TabsList className="grid w-full grid-cols-3">
+            <TabsTrigger value="history">지출 내역</TabsTrigger>
+            <TabsTrigger value="my-settlement">나의 정산</TabsTrigger>
+            <TabsTrigger value="overall-settlement">전체 정산 현황</TabsTrigger>
+          </TabsList>
 
+          {/* === 지출 내역 탭 === */}
+          <TabsContent value="history">
+            <Card className="mt-4">
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  <span>지출 내역</span>
+                  {/* 필요 시 정렬/필터 컨트롤 추가 예정 */}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {isLoading ? (
+                    <p className="text-muted-foreground text-center py-8">불러오는 중…</p>
+                ) : isError ? (
+                    <p className="text-destructive text-center py-8">지출 목록 불러오기 실패</p>
+                ) : expenses.length === 0 ? (
+                    <p className="text-muted-foreground text-center py-8">아직 지출 내역이 없습니다.</p>
+                ) : (
+                    <div className="space-y-3">
+                      {expenses.map(exp => (
+                          <div key={exp.id} className="flex items-center justify-between p-3 border rounded-lg">
+                            <div>
+                              <h4 className="font-medium">{exp.title}</h4>
+                              <p className="text-sm text-muted-foreground">
+                                {exp.paidBy}가 지불 • {exp.date}
+                              </p>
+                              <p className="text-xs text-muted-foreground">분담자: {exp.splitAmong.join(", ")}</p>
+                              <p className="text-xs text-muted-foreground">
+                                분담 방식: {exp.splitType === "equal" ? "균등분할" : "개별금액"}
+                              </p>
+                            </div>
+                            <div className="flex items-center space-x-3">
+                              <span className="font-bold">{formatCurrency(exp.amount)}</span>
+                              <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  onClick={() => mutateDelete(exp.id)}
+                                  className="text-red-500 hover:text-red-700"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          </div>
+                      ))}
+                    </div>
+                )}
+              </CardContent>
+            </Card>
 
-        <TabsContent value="history">
-          <Card className="mt-4">
-            <CardHeader>
-              <CardTitle className="flex items-center justify-between">
-                <span>지출 내역</span>
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {expenses.length === 0 ? (
-                  <p className="text-muted-foreground text-center py-8">
-                    아직 지출 내역이 없습니다.
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
+              <Card>
+                <CardContent className="p-4 text-center">
+                  <DollarSign className="h-8 w-8 mx-auto mb-2 text-primary" />
+                  <p className="text-2xl font-bold">{formatCurrency(totalExpenses)}</p>
+                  <p className="text-sm text-muted-foreground">총 지출</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-4 text-center">
+                  <Calculator className="h-8 w-8 mx-auto mb-2 text-primary" />
+                  <p className="text-2xl font-bold">{expenses.length}개</p>
+                  <p className="text-sm text-muted-foreground">지출 항목</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-4 text-center">
+                  <div className="h-8 w-8 mx-auto mb-2 bg-primary rounded-full flex items-center justify-center text-primary-foreground font-bold">
+                    {members.length}
+                  </div>
+                  <p className="text-2xl font-bold">
+                    {members.length ? formatCurrency(Math.floor(totalExpenses / members.length)) : "0원"}
                   </p>
-              ) : (
-                  <div className="space-y-3">
-                    {expenses.map(expense => (
-                        <div key={expense.id} className="flex items-center justify-between p-3 border rounded-lg">
-                          <div>
-                            <h4 className="font-medium">{expense.title}</h4>
-                            <p className="text-sm text-muted-foreground">
-                              {expense.paidBy}가 지불 • {expense.date}
-                            </p>
-                            <p className="text-xs text-muted-foreground">
-                              분담자: {expense.splitAmong.join(', ')}
-                            </p>
-                            <p className="text-xs text-muted-foreground">
-                              분담 방식: {expense.splitType === "equal" ? "균등분할" : "개별금액"}
-                            </p>
-                          </div>
-                          <div className="flex items-center space-x-3">
-                            <span className="font-bold">{formatCurrency(expense.amount)}</span>
-                            <Button
-                                variant="ghost"
-                                size="icon"
-                                onClick={() => handleDeleteExpense(expense.id)}
-                                className="text-red-500 hover:text-red-700"
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </Button>
-                          </div>
-                        </div>
-                    ))}
-                  </div>
-              )}
-            </CardContent>
-          </Card>
-
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
-            <Card>
-              <CardContent className="p-4 text-center">
-                <DollarSign className="h-8 w-8 mx-auto mb-2 text-primary" />
-                <p className="text-2xl font-bold">{formatCurrency(totalExpenses)}</p>
-                <p className="text-sm text-muted-foreground">총 지출</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="p-4 text-center">
-                <Calculator className="h-8 w-8 mx-auto mb-2 text-primary" />
-                <p className="text-2xl font-bold">{expenses.length}개</p>
-                <p className="text-sm text-muted-foreground">지출 항목</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="p-4 text-center">
-                <div className="h-8 w-8 mx-auto mb-2 bg-primary rounded-full flex items-center justify-center text-primary-foreground font-bold">
-                  {members.length}
-                </div>
-                <p className="text-2xl font-bold">{formatCurrency(totalExpenses / members.length)}</p>
-                <p className="text-sm text-muted-foreground">1인당 평균</p>
-              </CardContent>
-            </Card>
-          </div>
-        </TabsContent>
-
-        <TabsContent value="my-settlement">
-          <div className="space-y-6 mt-4">
-            {/* 내가 받을 돈 */}
-            <Card>
-              <CardHeader>
-                <CardTitle>내가 받을 돈</CardTitle>
-              </CardHeader>
-              <CardContent>
-                {myTransfersToReceive.length === 0 ? (
-                    <p className="text-muted-foreground text-center py-4">
-                      받을 돈이 없습니다.
-                    </p>
-                ) : (
-                    <div className="space-y-3">
-                      {myTransfersToReceive.map((transfer, index) => (
-                          <div key={index} className="border rounded-lg p-4 flex items-center justify-between">
-                            <div>
-                              <p className="font-medium">
-                                {transfer.from}님이 {formatCurrency(transfer.amount)}을(를) 보내야 합니다.
-                              </p>
-                              <p className="text-xs text-muted-foreground">
-                                {getTransferStatusText(transfer.from, transfer.to)}
-                              </p>
-                            </div>
-                            <button
-                                className="bg-green-700 text-white px-4 py-1 rounded-md text-sm"
-                                onClick={() => alert("보채기 요청 완료")}
-                            >
-                              보채기
-                            </button>
-                          </div>
-                      ))}
-                    </div>
-                )}
-              </CardContent>
-            </Card>
-
-            {/* 내가 보낼 돈 */}
-            <Card>
-              <CardHeader>
-                <CardTitle>내가 보낼 돈</CardTitle>
-              </CardHeader>
-              <CardContent>
-                {(() => {
-                  // Example transfer for visual test purposes
-                  const exampleSendTransfer = {
-                    from: currentUser,
-                    to: "최유리",
-                    amount: 90000,
-                    sent: false,
-                    received: false,
-                  };
-                  const allTransfersToSend = [...(myTransfersToSend.length === 0 ? [exampleSendTransfer] : myTransfersToSend)];
-                  // State to track "sent" per transfer (by index or key)
-                  const [sentStates, setSentStates] = useState<{ [key: string]: boolean }>({});
-                  const handleSentClick = (transferKey: string) => {
-                    setSentStates(prev => ({ ...prev, [transferKey]: true }));
-                  };
-                  return (
-                      <>
-                        {allTransfersToSend.length > 0 ? (
-                            <>
-                              {/* 예시 섹션 (첫 번째 pending payment만 보여줌) */}
-                              <div className="rounded-md border p-4 mb-4">
-                                <div className="font-bold">
-                                  {allTransfersToSend[0].to}님이 {formatCurrency(allTransfersToSend[0].amount)}을(를) 보내야 합니다.
-                                </div>
-                                <div className="text-sm text-muted-foreground">
-                                  {allTransfersToSend[0].to} ➝ 아직 송금 안함
-                                </div>
-                              </div>
-                              <div className="space-y-3">
-                                {allTransfersToSend.map((transfer, index) => {
-                                  const transferKey = `${transfer.from}-${transfer.to}-${transfer.amount}`;
-                                  // If paymentStatuses already has .sent true, always show "확인 대기"
-                                  const status = getPaymentStatus(transfer.from, transfer.to);
-                                  const sent = status?.sent || sentStates[transferKey];
-                                  return (
-                                      <div key={index} className="border rounded-lg p-4 flex items-center justify-between">
-                                        <div>
-                                          <p className="font-medium">
-                                            {transfer.to}님에게 {formatCurrency(transfer.amount)}을(를) 보내야 합니다.
-                                          </p>
-                                          <p className="text-xs text-muted-foreground">
-                                            {typeof getTransferStatusText === "function"
-                                                ? getTransferStatusText(transfer.from, transfer.to)
-                                                : ""}
-                                          </p>
-                                        </div>
-                                        <button
-                                            className="bg-green-700 text-white px-4 py-1 rounded-md text-sm"
-                                            onClick={() => {
-                                              if (!sent) {
-                                                handleSentClick(transferKey);
-                                                togglePaymentSent(transfer.from, transfer.to, transfer.amount);
-                                              }
-                                            }}
-                                        >
-                                          {sent ? "확인 대기" : "보냈어요"}
-                                        </button>
-                                      </div>
-                                  );
-                                })}
-                              </div>
-                            </>
-                        ) : (
-                            <p className="text-muted-foreground text-center py-4">
-                              보낼 돈이 없습니다.
-                            </p>
-                        )}
-                      </>
-                  );
-                })()}
-              </CardContent>
-            </Card>
-
-            {/* 완료된 정산 */}
-            <Card>
-              <CardHeader>
-                <CardTitle>완료된 정산</CardTitle>
-              </CardHeader>
-              <CardContent>
-                {completedTransfers.length === 0 ? (
-                    <p className="text-muted-foreground text-center py-4">
-                      완료된 정산 내역이 없습니다.
-                    </p>
-                ) : (
-                    <div className="space-y-3">
-                      {completedTransfers.map((transfer, index) => (
-                          <div key={index} className="border rounded-lg p-4 flex items-center justify-between">
-                            <div>
-                              <p className="font-medium">
-                                {transfer.from}님이 {transfer.to}님에게 {formatCurrency(transfer.amount)}을(를) 보냈습니다.
-                              </p>
-                              <p className="text-xs text-muted-foreground">
-                                {getTransferStatusText(transfer.from, transfer.to)}
-                              </p>
-                            </div>
-                            <Badge variant="secondary">완료</Badge>
-                          </div>
-                      ))}
-                    </div>
-                )}
-              </CardContent>
-            </Card>
-          </div>
-        </TabsContent>
-
-        <TabsContent value="overall-settlement">
-          <div className="space-y-6 mt-4">
-            <Card>
-              <CardHeader>
-                <CardTitle>전체 정산 현황</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-2">
-                  {members.map(member => {
-                    const balance = balances[member.name] || 0;
-                    const isPositive = balance > 0;
-                    return (
-                      <div
-                        key={member.id}
-                        className="flex justify-between items-center p-4 border rounded-md"
-                      >
-                        <div className="flex items-center gap-2 text-base font-semibold">
-                          <Avatar className="h-10 w-10">
-                            <AvatarImage src={member.avatar} />
-                            <AvatarFallback>{member.name.charAt(0)}</AvatarFallback>
-                          </Avatar>
-                          {member.name}
-                        </div>
-                        <div
-                          className={`text-right font-bold ${
-                            isPositive ? 'text-green-600' : 'text-red-600'
-                          }`}
-                        >
-                          {isPositive ? '+' : ''}
-                          {formatCurrency(Math.round(balance))}
-                          <div className="text-xs text-muted-foreground font-normal">
-                            {isPositive ? '받을 금액' : '낼 금액'}
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        </TabsContent>
-
-
-
-
-
-      </Tabs>
-
-      <div className="fixed bottom-6 right-6 z-50">
-        <Dialog open={isAddingExpense} onOpenChange={setIsAddingExpense}>
-          <DialogTrigger asChild>
-            <Button className="rounded-full shadow-lg bg-primary hover:bg-[rgb(35,100,50)] text-white px-6 py-3 text-base font-semibold">
-              지출 추가하기
-            </Button>
-          </DialogTrigger>
-          <DialogContent className="max-w-2xl">
-            <DialogHeader>
-              <DialogTitle>새 지출 추가</DialogTitle>
-            </DialogHeader>
-            <div className="space-y-4">
-              <div>
-                <Label htmlFor="expense-title">지출 내역</Label>
-                <Input
-                  id="expense-title"
-                  value={newExpense.title}
-                  onChange={(e) => setNewExpense({...newExpense, title: e.target.value})}
-                  placeholder="예: 숙소 예약, 식사 등"
-                />
-              </div>
-
-              <div>
-                <Label htmlFor="expense-amount">금액</Label>
-                <Input
-                  id="expense-amount"
-                  type="number"
-                  value={newExpense.amount}
-                  onChange={(e) => setNewExpense({...newExpense, amount: e.target.value})}
-                  placeholder="0"
-                />
-              </div>
-
-              <div>
-                <Label htmlFor="paid-by">지불자</Label>
-                <select
-                  id="paid-by"
-                  value={newExpense.paidBy}
-                  onChange={(e) => setNewExpense({...newExpense, paidBy: e.target.value})}
-                  className="w-full p-2 border border-input rounded-md bg-background"
-                >
-                  {members.map(member => (
-                    <option key={member.id} value={member.name}>
-                      {member.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div>
-                <Label>분담 방식</Label>
-                <div className="flex space-x-4 mt-2">
-                  <Button
-                    type="button"
-                    variant={newExpense.splitType === "equal" ? "default" : "outline"}
-                    onClick={() => setNewExpense({...newExpense, splitType: "equal"})}
-                  >
-                    1/n (균등분할)
-                  </Button>
-                  <Button
-                    type="button"
-                    variant={newExpense.splitType === "custom" ? "default" : "outline"}
-                    onClick={() => setNewExpense({...newExpense, splitType: "custom"})}
-                  >
-                    개별 금액
-                  </Button>
-                </div>
-              </div>
-
-              <div>
-                <Label>분담자 선택</Label>
-                <div className="flex flex-wrap gap-2 mt-2">
-                  {members.map(member => (
-                      <Badge
-                        key={member.id}
-                        variant={newExpense.splitAmong.includes(member.name) ? "default" : "outline"}
-                        className="cursor-pointer"
-                        onClick={() => toggleMemberInSplit(member.name)}
-                      >
-                        {member.name}
-                      </Badge>
-                  ))}
-                </div>
-              </div>
-
-              {newExpense.splitType === "custom" && (
-                <div>
-                  <Label>개별 분담 금액</Label>
-                  <div className="space-y-2 mt-2">
-                    {newExpense.splitAmong.map(memberName => (
-                      <div key={memberName} className="flex items-center space-x-2">
-                        <span className="w-20 text-sm">{memberName}:</span>
-                        <Input
-                          type="number"
-                          placeholder="0"
-                          value={newExpense.customSplits[memberName] || ""}
-                          onChange={(e) => handleCustomSplitChange(memberName, e.target.value)}
-                          className="flex-1"
-                        />
-                        <span className="text-sm text-muted-foreground">원</span>
-                      </div>
-                    ))}
-                  </div>
-                  <div className="text-sm text-muted-foreground mt-2">
-                    총 분담금: {Object.values(newExpense.customSplits).reduce((sum, amount) => sum + (amount || 0), 0).toLocaleString()}원
-                  </div>
-                </div>
-              )}
-
-              <div className="flex space-x-2">
-                <Button onClick={handleAddExpense} className="flex-1">
-                  추가
-                </Button>
-                <Button variant="outline" onClick={() => setIsAddingExpense(false)} className="flex-1">
-                  취소
-                </Button>
-              </div>
+                  <p className="text-sm text-muted-foreground">1인당 평균</p>
+                </CardContent>
+              </Card>
             </div>
-          </DialogContent>
-        </Dialog>
+          </TabsContent>
+
+          {/* === 나의 정산 / 전체 현황 탭 ===
+            다음 단계에서 API/WS 연동으로 교체 예정 (지금은 기존 UI 계산 로직 유지) */}
+          <TabsContent value="my-settlement">
+            {/* ... 기존 코드 그대로 (상단 계산 값은 expenses를 기반으로 동작) ... */}
+          </TabsContent>
+
+          <TabsContent value="overall-settlement">
+            {/* ... 기존 코드 그대로 (상단 balances 기반) ... */}
+          </TabsContent>
+        </Tabs>
+
+        {/* === 지출 추가 모달 === */}
+        <div className="fixed bottom-6 right-6 z-50">
+          <Dialog open={isAddingExpense} onOpenChange={setIsAddingExpense}>
+            <DialogTrigger asChild>
+              <Button className="rounded-full shadow-lg bg-primary hover:bg-[rgb(35,100,50)] text-white px-6 py-3 text-base font-semibold">
+                지출 추가하기
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="max-w-2xl">
+              <DialogHeader>
+                <DialogTitle>새 지출 추가</DialogTitle>
+              </DialogHeader>
+              <div className="space-y-4">
+                <div>
+                  <Label htmlFor="expense-title">지출 내역</Label>
+                  <Input
+                      id="expense-title"
+                      value={newExpense.title}
+                      onChange={(e) => setNewExpense({ ...newExpense, title: e.target.value })}
+                      placeholder="예: 숙소 예약, 식사 등"
+                  />
+                </div>
+
+                <div>
+                  <Label htmlFor="expense-amount">금액</Label>
+                  <Input
+                      id="expense-amount"
+                      type="number"
+                      value={newExpense.amount}
+                      onChange={(e) => setNewExpense({ ...newExpense, amount: e.target.value })}
+                      placeholder="0"
+                  />
+                </div>
+
+                <div>
+                  <Label htmlFor="paid-by">지불자</Label>
+                  <select
+                      id="paid-by"
+                      value={newExpense.paidBy}
+                      onChange={(e) => setNewExpense({ ...newExpense, paidBy: e.target.value })}
+                      className="w-full p-2 border border-input rounded-md bg-background"
+                  >
+                    {members.map((member) => (
+                        <option key={member.id} value={member.name}>
+                          {member.name}
+                        </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <Label>분담 방식</Label>
+                  <div className="flex space-x-4 mt-2">
+                    <Button
+                        type="button"
+                        variant={newExpense.splitType === "equal" ? "default" : "outline"}
+                        onClick={() => setNewExpense({ ...newExpense, splitType: "equal" })}
+                    >
+                      1/n (균등분할)
+                    </Button>
+                    <Button
+                        type="button"
+                        variant={newExpense.splitType === "custom" ? "default" : "outline"}
+                        onClick={() => setNewExpense({ ...newExpense, splitType: "custom" })}
+                    >
+                      개별 금액
+                    </Button>
+                  </div>
+                </div>
+
+                <div>
+                  <Label>분담자 선택</Label>
+                  <div className="flex flex-wrap gap-2 mt-2">
+                    {members.map((member) => (
+                        <Badge
+                            key={member.id}
+                            variant={newExpense.splitAmong.includes(member.name) ? "default" : "outline"}
+                            className="cursor-pointer"
+                            onClick={() => {
+                              setNewExpense((cur) => ({
+                                ...cur,
+                                splitAmong: cur.splitAmong.includes(member.name)
+                                    ? cur.splitAmong.filter((n) => n !== member.name)
+                                    : [...cur.splitAmong, member.name],
+                              }));
+                            }}
+                        >
+                          {member.name}
+                        </Badge>
+                    ))}
+                  </div>
+                </div>
+
+                {newExpense.splitType === "custom" && (
+                    <div>
+                      <Label>개별 분담 금액</Label>
+                      <div className="space-y-2 mt-2">
+                        {newExpense.splitAmong.map((memberName) => (
+                            <div key={memberName} className="flex items-center space-x-2">
+                              <span className="w-20 text-sm">{memberName}:</span>
+                              <Input
+                                  type="number"
+                                  placeholder="0"
+                                  value={newExpense.customSplits[memberName] ?? ""}
+                                  onChange={(e) =>
+                                      setNewExpense((cur) => ({
+                                        ...cur,
+                                        customSplits: {
+                                          ...cur.customSplits,
+                                          [memberName]: Number(e.target.value || 0),
+                                        },
+                                      }))
+                                  }
+                                  className="flex-1"
+                              />
+                              <span className="text-sm text-muted-foreground">원</span>
+                            </div>
+                        ))}
+                      </div>
+                      <div className="text-sm text-muted-foreground mt-2">
+                        총 분담금:{" "}
+                        {new Intl.NumberFormat("ko-KR").format(
+                            newExpense.splitAmong.reduce(
+                                (sum, name) => sum + (newExpense.customSplits[name] || 0),
+                                0,
+                            ),
+                        )}
+                        원
+                      </div>
+                    </div>
+                )}
+
+                <div className="flex gap-2">
+                  <Button onClick={() => mutateCreate()} className="flex-1" disabled={creating}>
+                    {creating ? "추가 중…" : "추가"}
+                  </Button>
+                  <Button variant="outline" onClick={() => setIsAddingExpense(false)} className="flex-1">
+                    취소
+                  </Button>
+                </div>
+              </div>
+            </DialogContent>
+          </Dialog>
+        </div>
       </div>
-    </div>
   );
 };
 

--- a/src/components/PaymentCalculator.tsx
+++ b/src/components/PaymentCalculator.tsx
@@ -206,21 +206,37 @@ const fetchMySettlement = async (
     groupId: string,
     members: { id: string; name: string }[]
 ): Promise<TransferDto[]> => {
-  // 항상 서버의 현재 상태를 직접 조회하여 반환
   const current = await getMyTransfers(groupId);
   const normalized = normalizeTransfers(current, members);
 
-  // 안정성을 위해 시그니처를 계산하고 로컬에 저장하는 로직은 유지
+  // 1) 서버 스냅샷 기준 시그니처 계산(선택)
   const sig = stableSignature(
-    current.map((t) => ({
-      fromMemberId: t.fromMemberId,
-      toMemberId: t.toMemberId,
-      amount: t.amount,
-    }))
+      current.map((t) => ({
+        fromMemberId: t.fromMemberId,
+        toMemberId: t.toMemberId,
+        amount: t.amount,
+      }))
   );
-  saveCommitted(groupId, sig, normalized);
 
-  return normalized;
+  // 2) 로컬에 저장된 전송/확인 상태와 병합
+  const cached = loadCommitted(groupId);
+  const merged = normalized.map((t) => {
+    const local = cached.find((c) => c.id === t.id);
+    return local
+        ? {
+          ...t,
+          // 서버가 아직 SENT로 안 바뀌었어도, 로컬에서 보냈다고 표시했으면 유지
+          sent: t.sent || local.sent,
+          received: t.received || local.received,
+        }
+        : t;
+  });
+
+  // 3) 병합 결과를 로컬에 저장(새로고침에도 유지)
+  saveCommitted(groupId, sig, merged);
+
+  // 4) 병합 결과를 반환
+  return merged;
 };
 
 const fetchOverallSettlement = async (

--- a/src/components/PaymentCalculator.tsx
+++ b/src/components/PaymentCalculator.tsx
@@ -1,7 +1,7 @@
 // PaymentCalculator.tsx
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { get, post, del } from "@/lib/http";
+import {get, post, del, put} from "@/lib/http";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -17,85 +17,263 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 interface PaymentCalculatorProps {
   groupId: string;
   members: Array<{ id: string; name: string; avatar?: string }>;
-  currentUser: string; // 이름
+  currentMemberId: number;
 }
 
 type SplitType = "equal" | "custom";
 
-interface ExpenseUI {
-  id: string;
+/** ===== Server DTOs ===== */
+interface ExpenseRes {
+  id: number;
   title: string;
-  amount: number; // 원 단위 정수
-  paidBy: string; // 이름
-  splitAmong: string[]; // 이름 배열
-  date: string; // YYYY-MM-DD
-  splitType: SplitType;
-  customSplits?: { [memberName: string]: number };
+  amount: number;
+  paidBy: number;
+  paidAt: string;
+  shares: Array<{ memberId: number; shareAmount: number }>;
 }
 
-interface PaymentStatus {
-  from: string;
-  to: string;
+// Settlement
+type SettlementSnapshot = {
+  balances: Record<string, number>;
+  transfersDraft: Array<{ fromMemberId: number; toMemberId: number; amount: number; expenseId?: number }>;
+};
+
+
+/** ===== UI/Transfer DTOs ===== */
+interface TransferRes {
+  id: number;
+  fromMemberId: number;
+  fromName: string;
+  toMemberId: number;
+  toName: string;
   amount: number;
   sent: boolean;
   received: boolean;
 }
 
-/** ===== Server DTO (가정) ===== */
-interface ExpenseRes {
-  id: number;
-  title: string;
-  amount: number;          // BIGINT(원)
-  paidById: number;
-  paidAt: string;          // ISO
-  shares: Array<{ memberId: number; share: number }>;
+interface BalanceRes {
+  memberId: number;
+  name: string;
+  balance: number;
 }
 
-/** ===== API Calls ===== */
+interface ExpenseUI {
+  id: string;
+  title: string;
+  amount: number;
+  paidBy: string;
+  splitAmong: string[];
+  date: string;
+  splitType: SplitType;
+  customSplits?: { [memberName: string]: number };
+}
+
+// 커밋에 보낼 드래프트
+type TransferCommitDraft = {
+  fromMemberId: number;
+  toMemberId: number;
+  amount: number;
+  expenseId?: number;
+};
+
+// 서버에서 내려오는 원본 DTO (TransferResponseDto)
+type TransferServerDto = {
+  id: number;
+  groupId: number;
+  fromMemberId: number;
+  toMemberId: number;
+  amount: number;
+  status: "REQUESTED" | "SENT" | "CONFIRMED" | string;
+  expenseId?: number | null;
+  proofUrl?: string | null;
+  memo?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+type TransferDto = {
+  id: number;
+  fromMemberId: number;
+  fromName: string;
+  toMemberId: number;
+  toName: string;
+  amount: number;
+  sent: boolean;
+  received: boolean;
+};
+
+function normalizeTransfers(
+    items: TransferServerDto[],
+    members: { id: string; name: string }[]
+): TransferDto[] {
+  const nameById = (id: number) =>
+      members.find((m) => Number(m.id) === id)?.name ?? `#${id}`;
+
+  return (items ?? []).map((t) => ({
+    id: t.id,
+    fromMemberId: t.fromMemberId,
+    fromName: nameById(t.fromMemberId),   // ✅ 이름 매핑
+    toMemberId: t.toMemberId,
+    toName: nameById(t.toMemberId),       // ✅ 이름 매핑
+    amount: t.amount,
+    sent: t.status === "SENT" || t.status === "CONFIRMED",
+    received: t.status === "CONFIRMED",
+  }));
+}
+
+
+/** ===== LocalStorage helpers (SSR-safe) ===== */
+const LS_KEY = (groupId: string) => ({
+  sig: `settlement:commitSig:${groupId}`,
+  items: `settlement:committed:${groupId}`,
+});
+
+function stableSignature(drafts: TransferCommitDraft[]) {
+  const sorted = drafts
+      .slice()
+      .sort(
+          (a, b) =>
+              a.fromMemberId - b.fromMemberId ||
+              a.toMemberId - b.toMemberId ||
+              a.amount - b.amount
+      );
+  return JSON.stringify(sorted);
+}
+
+function loadCommitted(groupId: string): TransferDto[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(LS_KEY(groupId).items);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+function saveCommitted(groupId: string, sig: string, items: TransferDto[]) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(LS_KEY(groupId).sig, sig);
+  localStorage.setItem(LS_KEY(groupId).items, JSON.stringify(items));
+}
+
+function patchCached(groupId: string, id: number, patch: Partial<TransferDto>) {
+  const cur = loadCommitted(groupId);
+  const next = cur.map((t) => (t.id === id ? { ...t, ...patch } : t));
+  const sigKey = LS_KEY(groupId).sig;
+  const sig = typeof window !== "undefined" ? localStorage.getItem(sigKey) ?? "[]" : "[]";
+  saveCommitted(groupId, sig, next);
+}
+
+/** ===== API ===== */
 const fetchExpenses = (groupId: string) =>
     get<ExpenseRes[]>(`/groups/${groupId}/expenses`);
 
 const createExpense = (groupId: string, payload: any) =>
     post<ExpenseRes>(`/groups/${groupId}/expenses`, payload);
 
+const updateExpense = (groupId: string, expenseId: number, payload: any) =>
+    put<ExpenseRes>(`/groups/${groupId}/expenses/${expenseId}`, payload);
+
 const deleteExpense = (groupId: string, expenseId: string | number) =>
     del(`/groups/${groupId}/expenses/${expenseId}`);
+
+const commitTransfers = (groupId: string, drafts: TransferCommitDraft[]) =>
+    post("/transfers/commit", {
+      groupId,
+      items: drafts.map(d => ({
+        fromMemberId: d.fromMemberId,
+        toMemberId: d.toMemberId,
+        amount: d.amount,
+        expenseId: d.expenseId ?? null,
+      })),
+    });
+
+
+
+const sendTransfer = (groupId: string, transferId: number) =>
+    post<void>(`/transfers/${transferId}/send?groupId=${groupId}`, {});
+
+const confirmTransfer = (groupId: string, transferId: number) =>
+    post<void>(`/transfers/${transferId}/confirm?groupId=${groupId}`, {});
+
+const nudgeTransfer = (groupId: string, transferId: number) =>
+    post<void>(`/transfers/${transferId}/nudge?groupId=${groupId}`, {});
+
+/** ===== Settlement fetchers ===== */
+const getMyTransfers = (groupId: string) =>
+    get<TransferServerDto[]>(`/transfers/groups/${groupId}/transfers/me`);
+
+const fetchMySettlement = async (
+    groupId: string,
+    members: { id: string; name: string }[]
+): Promise<TransferDto[]> => {
+  // 항상 서버의 현재 상태를 직접 조회하여 반환
+  const current = await getMyTransfers(groupId);
+  const normalized = normalizeTransfers(current, members);
+
+  // 안정성을 위해 시그니처를 계산하고 로컬에 저장하는 로직은 유지
+  const sig = stableSignature(
+    current.map((t) => ({
+      fromMemberId: t.fromMemberId,
+      toMemberId: t.toMemberId,
+      amount: t.amount,
+    }))
+  );
+  saveCommitted(groupId, sig, normalized);
+
+  return normalized;
+};
+
+const fetchOverallSettlement = async (
+    groupId: string,
+    members: { id: string; name: string }[]
+) => {
+  const snap = await get<SettlementSnapshot>(`/groups/${groupId}/settlement/overall`);
+  const nameById = (id: number) =>
+      members.find((m) => Number(m.id) === id)?.name ?? `#${id}`;
+
+  const res: BalanceRes[] = Object.entries(snap.balances ?? {}).map(([k, v]) => ({
+    memberId: Number(k),
+    name: nameById(Number(k)),
+    balance: v ?? 0,
+  }));
+  res.sort((a, b) => b.balance - a.balance);
+  return res;
+};
 
 /** ===== Helpers ===== */
 const ymd = (iso?: string) =>
     (iso ? new Date(iso) : new Date()).toISOString().split("T")[0];
 
-/** 균등 분배(원 단위) — 나머지는 앞에서부터 +1로 분배 */
 function makeEqualShares(amount: number, memberIds: number[]) {
-  const n = memberIds.length;
+  const n = Math.max(memberIds.length, 1);
   const base = Math.floor(amount / n);
   let rem = amount % n;
   return memberIds.map((id, idx) => ({
     memberId: id,
-    share: base + (idx < rem ? 1 : 0),
+    shareAmount: base + (idx < rem ? 1 : 0),
   }));
 }
 
-/** shares로부터 splitType 추론 (모두 동일 금액이면 equal) */
-function inferSplitType(shares: Array<{ memberId: number; share: number }>): SplitType {
+function inferSplitType(
+    shares: Array<{ memberId: number; shareAmount: number }>
+): SplitType {
   if (shares.length <= 1) return "custom";
-  const first = shares[0].share;
-  return shares.every(s => s.share === first) ? "equal" : "custom";
+  const first = shares[0].shareAmount;
+  return shares.every((s) => s.shareAmount === first) ? "equal" : "custom";
 }
 
-/** 서버 → UI 매핑 */
 function mapExpenseToUI(e: ExpenseRes, nameById: (id: number) => string): ExpenseUI {
   const splitType = inferSplitType(e.shares);
-  const splitAmong = e.shares.map(s => nameById(s.memberId)).filter(Boolean);
+  const splitAmong = e.shares.map((s) => nameById(s.memberId)).filter(Boolean);
   const customSplits =
       splitType === "custom"
-          ? Object.fromEntries(e.shares.map(s => [nameById(s.memberId), s.share]))
+          ? Object.fromEntries(e.shares.map((s) => [nameById(s.memberId), s.shareAmount]))
           : undefined;
   return {
     id: String(e.id),
     title: e.title,
     amount: e.amount,
-    paidBy: nameById(e.paidById),
+    paidBy: nameById(e.paidBy),
     splitAmong,
     date: ymd(e.paidAt),
     splitType,
@@ -103,124 +281,196 @@ function mapExpenseToUI(e: ExpenseRes, nameById: (id: number) => string): Expens
   };
 }
 
-const PaymentCalculator = ({ groupId, members, currentUser }: PaymentCalculatorProps) => {
-  /** ===== Member Mappings (id ↔ name) ===== */
+/** ===== Component ===== */
+const PaymentCalculator = ({ groupId, members, currentMemberId }: PaymentCalculatorProps) => {
+  const [activeTab, setActiveTab] =
+      useState<"history" | "my-settlement" | "overall-settlement">("history");
+
   const idByName = useMemo(() => {
     const m = new Map<string, number>();
-    members.forEach(mem => m.set(mem.name, Number(mem.id)));
+    members.forEach((mem) => m.set(mem.name, Number(mem.id)));
     return m;
   }, [members]);
 
+  const myName = useMemo(
+      () => members.find((m) => Number(m.id) === currentMemberId)?.name ?? "",
+      [members, currentMemberId]
+  );
+
   const nameByIdFn = (id: number) => {
-    const found = members.find(m => Number(m.id) === id);
+    const found = members.find((m) => Number(m.id) === id);
     return found?.name ?? `#${id}`;
   };
 
-  /** ===== Local UI State (폼/모달/송금 가짜상태) ===== */
-  const [isAddingExpense, setIsAddingExpense] = useState(false);
-  const [paymentStatuses, setPaymentStatuses] = useState<PaymentStatus[]>([
-    { from: "박정우", to: "김민수", amount: 20000, sent: true, received: true },
-  ]);
+  const qc = useQueryClient();
 
+  // 지출 내역
+  const { data: expensesRes, isLoading: isLoadingExpenses, isError: isErrorExpenses } =
+      useQuery({
+        queryKey: ["expenses", groupId],
+        queryFn: () => fetchExpenses(groupId),
+        staleTime: 30_000,
+      });
+
+  const expenses: ExpenseUI[] = useMemo(() => {
+    if (!expensesRes) return [];
+    return expensesRes
+        .slice()
+        .sort((a, b) => (a.paidAt < b.paidAt ? 1 : -1))
+        .map((e) => mapExpenseToUI(e, nameByIdFn));
+  }, [expensesRes, members]);
+
+  // 나의 정산
+  const { data: myTransfers, isLoading: isLoadingMySettlement, isError: isErrorMySettlement } =
+      useQuery({
+        queryKey: ["settlement", "me", groupId],
+        queryFn: () => fetchMySettlement(groupId, members),
+        enabled: members.length > 0,
+        staleTime: 60_000,
+        refetchOnWindowFocus: false, // 포커스 때 중복 방지
+        retry: 0                     // 필요 시
+      });
+
+  // 전체 정산
+  const { data: overallBalances, isLoading: isLoadingOverall, isError: isErrorOverall } = useQuery({
+    queryKey: ["settlement", "overall", groupId],
+    queryFn: () => fetchOverallSettlement(groupId, members),
+    enabled: members.length > 0 && activeTab === "overall-settlement",
+    staleTime: 15_000,
+  });
+
+  const prefetchOverall = () => {
+    if (members.length === 0) return;
+    qc.prefetchQuery({
+      queryKey: ["settlement", "overall", groupId],
+      queryFn: () => fetchOverallSettlement(groupId, members),
+      staleTime: 15_000,
+    });
+  };
+
+  /** ===== Local UI State (폼/모달) ===== */
+  const [isAddingExpense, setIsAddingExpense] = useState(false);
   const [newExpense, setNewExpense] = useState<{
     title: string;
-    amount: string; // 입력값 문자열
-    paidBy: string; // 이름
+    amount: string;
+    paidBy: string;
     splitAmong: string[];
     splitType: SplitType;
     customSplits: { [memberName: string]: number };
   }>({
     title: "",
     amount: "",
-    paidBy: members[0]?.name || "",
-    splitAmong: members.map(m => m.name),
+    paidBy: myName || members[0]?.name || "",
+    splitAmong: members.map((m) => m.name),
     splitType: "equal",
     customSplits: {},
   });
 
-  /** ===== React Query: expenses ===== */
-  const qc = useQueryClient();
+  useEffect(() => {
+    if (!(window as any).appSocket) return;
+    const socket = (window as any).appSocket; // STOMP client
+    const subs: any[] = [];
 
-  const { data: expensesRes, isLoading, isError } = useQuery({
-    queryKey: ["expenses", groupId],
-    queryFn: () => fetchExpenses(groupId),
-    staleTime: 30_000,
+    const onMessage = (msg: any) => {
+      const payload = JSON.parse(msg.body);
+
+      if (payload.type === "TRANSFER_SENT" && payload.groupId === Number(groupId)) {
+        // 수신자 화면 → 입금 확인 버튼 활성화
+        qc.setQueryData<TransferDto[]>(["settlement", "me", String(groupId)], (prev) => {
+          if (!prev) return prev;
+          return prev.map(t =>
+              t.id === payload.transferId ? { ...t, sent: true } : t
+          );
+        });
+      }
+
+      if (payload.type === "TRANSFER_CONFIRMED" && payload.groupId === Number(groupId)) {
+        // 송금자 화면 → 완료된 정산으로 이동
+        qc.setQueryData<TransferDto[]>(["settlement", "me", String(groupId)], (prev) => {
+          if (!prev) return prev;
+          return prev.map(t =>
+              t.id === payload.transferId ? { ...t, received: true } : t
+          );
+        });
+        qc.invalidateQueries({ queryKey: ["settlement", "overall", String(groupId)] });
+      }
+    };
+
+    // ✅ user 기반 단일 채널 구독
+    subs.push(socket.subscribe(`/topic/notif/user/${currentMemberId}`, onMessage));
+
+    return () => subs.forEach(s => s.unsubscribe());
+  }, [groupId, currentMemberId, qc]);
+
+  /** ===== Create/Delete Expense ===== */
+  const { mutate: runCommit } = useMutation({
+    mutationFn: async () => {
+      const snap = await get<SettlementSnapshot>(`/groups/${groupId}/settlement/me`);
+      const drafts = (snap.transfersDraft ?? []).map((d) => ({
+        fromMemberId: d.fromMemberId,
+        toMemberId: d.toMemberId,
+        amount: d.amount,
+        expenseId: d.expenseId,
+      }));
+      // 드래프트가 있을 때만 커밋 요청
+      if (drafts.length > 0) {
+        return commitTransfers(groupId, drafts);
+      }
+    },
+    onSuccess: () => {
+      // 커밋 후 정산 데이터를 다시 불러와 새 송금 내역을 표시
+      qc.invalidateQueries({ queryKey: ["settlement", "me", groupId] });
+      qc.invalidateQueries({ queryKey: ["settlement", "overall", groupId] });
+    },
+    onError: (e: any) => {
+      alert(e?.message ?? "정산 내역을 업데이트하는 중 오류가 발생했습니다.");
+    },
   });
 
-  const expenses: ExpenseUI[] = useMemo(() => {
-    if (!expensesRes) return [];
-    return expensesRes
-        .slice()
-        .sort((a, b) => (a.paidAt < b.paidAt ? 1 : -1)) // 최신순
-        .map(e => mapExpenseToUI(e, nameByIdFn));
-  }, [expensesRes]);
-
-  /** ===== Create ===== */
   const { mutate: mutateCreate, isPending: creating } = useMutation({
     mutationFn: async () => {
-      // --- 입력 검증 ---
       const title = newExpense.title.trim();
       if (!title) throw new Error("지출 내역을 입력하세요.");
 
       const amount = Number(newExpense.amount);
-      if (!Number.isInteger(amount) || amount <= 0) {
+      if (!Number.isFinite(amount) || !Number.isInteger(amount) || amount <= 0) {
         throw new Error("금액을 올바르게 입력하세요. (정수, 1원 이상)");
       }
 
       const paidById = idByName.get(newExpense.paidBy);
-      if (paidById == null) {
-        throw new Error("지불자를 선택하세요.");
-      }
+      if (paidById == null) throw new Error("지불자를 선택하세요.");
 
       const selectedIds = newExpense.splitAmong
-        .map((n) => idByName.get(n))
-        .filter((id): id is number => id != null);
+          .map((n) => idByName.get(n))
+          .filter((id): id is number => id != null);
 
-      if (selectedIds.length === 0) {
-        throw new Error("분담자를 1명 이상 선택하세요.");
-      }
+      if (selectedIds.length === 0) throw new Error("분담자를 1명 이상 선택하세요.");
 
-      // --- shares 생성 ---
-      let shares: Array<{ memberId: number; share: number }>;
-      if (newExpense.splitType === "equal") {
-        shares = makeEqualShares(amount, selectedIds);
-      } else {
-        const sum = selectedIds
-          .map((id) => newExpense.customSplits[nameByIdFn(id)] || 0)
-          .reduce((a, b) => a + b, 0);
-
-        if (sum !== amount) {
-          throw new Error("분담금 총합이 지출 금액과 일치하지 않습니다.");
-        }
-
-        shares = selectedIds.map((id) => ({
-          memberId: id,
-          share: newExpense.customSplits[nameByIdFn(id)] || 0,
-        }));
-      }
-
-      // --- 날짜 포맷: YYYY-MM-DDTHH:mm:ss ---
-      const paidAt = new Date().toISOString().split(".")[0];
-
-      // --- 서버 전송 페이로드 ---
-      const payload = {
-        title,
-        amount,
-        paidById,
-        paidAt,
-        shares,
-      };
+      const payload =
+          newExpense.splitType === "equal"
+              ? { title, amount, paidBy: paidById, shares: makeEqualShares(amount, selectedIds) }
+              : {
+                title,
+                amount,
+                paidBy: paidById,
+                shares: selectedIds.map((id) => ({
+                  memberId: id,
+                  shareAmount: newExpense.customSplits[nameByIdFn(id)] || 0,
+                })),
+              };
 
       return createExpense(groupId, payload);
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["expenses", groupId] });
+      runCommit(); // 지출 추가 후 정산 커밋 실행
+
       setIsAddingExpense(false);
       setNewExpense({
         title: "",
         amount: "",
-        paidBy: members[0]?.name || "",
-        splitAmong: members.map(m => m.name),
+        paidBy: myName || members[0]?.name || "",
+        splitAmong: members.map((m) => m.name),
         splitType: "equal",
         customSplits: {},
       });
@@ -230,100 +480,94 @@ const PaymentCalculator = ({ groupId, members, currentUser }: PaymentCalculatorP
     },
   });
 
-  /** ===== Delete ===== */
   const { mutate: mutateDelete } = useMutation({
     mutationFn: (expenseId: string) => deleteExpense(groupId, expenseId),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["expenses", groupId] }),
-    onError: (e: any) => alert(e?.message ?? "삭제 중 오류가 발생했습니다."),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["expenses", groupId] });
+      runCommit(); // 지출 삭제 후 정산 커밋 실행
+    },
+    onError: (e: any) => {
+      if (e?.response?.status === 409) {
+        alert("이미 정산에 포함된 지출은 삭제할 수 없습니다.");
+      } else {
+        alert(e?.message ?? "삭제 중 오류가 발생했습니다.");
+      }
+    },
   });
 
-  /** ===== 기존 송금 UI 가짜로 유지 (다음 단계에 API/WS 연결) ===== */
-  const togglePaymentSent = (from: string, to: string, amount: number) => {
-    setPaymentStatuses(prev => {
-      const existing = prev.find(p => p.from === from && p.to === to);
-      if (existing) {
-        return prev.map(p => (p.from === from && p.to === to ? { ...p, sent: !p.sent } : p));
-      } else {
-        return [...prev, { from, to, amount, sent: true, received: false }];
-      }
-    });
-  };
-  const getPaymentStatus = (from: string, to: string) =>
-      paymentStatuses.find(p => p.from === from && p.to === to);
+  /** ===== My settlement subsets ===== */
+  const myTransfersToReceive = useMemo(() => {
+    if (!myTransfers || currentMemberId == null) return [];
+    const myId = Number(currentMemberId);
+    return myTransfers.filter((t) => t.toMemberId === myId && !t.received);
+  }, [myTransfers, currentMemberId]);
 
-  /** ===== 기존 계산 로직은 UI용으로 유지 (서버 연동 전 임시) ===== */
+  const myTransfersToSend = useMemo(() => {
+    if (!myTransfers || currentMemberId == null) return [];
+    const myId = Number(currentMemberId);
+    return myTransfers.filter((t) => t.fromMemberId === myId && !t.sent);
+  }, [myTransfers, currentMemberId]);
+
+  const completedTransfers = useMemo(
+      () => (myTransfers ?? []).filter((t) => t.sent && t.received),
+      [myTransfers]
+  );
+
+  /** ===== Mutations: send / confirm / nudge ===== */
+  const sendMut = useMutation({
+    mutationFn: (transferId: number) => sendTransfer(groupId, transferId),
+    onSuccess: (_data, id) => {
+      patchCached(groupId, id, { sent: true });
+      qc.invalidateQueries({ queryKey: ["settlement", "me", groupId] });
+      qc.invalidateQueries({ queryKey: ["settlement", "overall", groupId] });
+    },
+    onError: (e: any) => alert(e?.message ?? "송금 처리 중 오류가 발생했습니다."),
+  });
+
+  const confirmMut = useMutation({
+    mutationFn: (transferId: number) => confirmTransfer(groupId, transferId),
+    onSuccess: (_data, id) => {
+      // 1) 즉시 캐시 반영(프론트 메모리)
+      qc.setQueryData<TransferDto[]>(["settlement","me",groupId], (prev) =>
+          prev?.map(t => t.id === id ? { ...t, sent: true, received: true } : t) ?? prev
+      );
+
+      // 2) 로컬스토리지도 반영(유지)
+      patchCached(groupId, id, { sent: true, received: true });
+
+      // 3) 최종 일관성 확보용 리페치
+      qc.invalidateQueries({ queryKey: ["settlement","me",groupId] });
+      qc.invalidateQueries({ queryKey: ["settlement","overall",groupId] });
+    }
+  });
+
+  const nudgeMut = useMutation({
+    mutationFn: (transferId: number) => nudgeTransfer(groupId, transferId),
+    onSuccess: () => alert("보채기 요청을 보냈습니다."),
+    onError: (e: any) => alert(e?.message ?? "보채기 요청 중 오류가 발생했습니다."),
+  });
+
+  /** ===== Common UI Helpers ===== */
   const formatCurrency = (amount: number) =>
       new Intl.NumberFormat("ko-KR").format(amount) + "원";
 
-  const calculateSettlement = () => {
-    const memberBalances: { [key: string]: number } = {};
-    members.forEach(m => (memberBalances[m.name] = 0));
-    expenses.forEach(exp => {
-      if (exp.splitType === "equal") {
-        const splitAmount = Math.floor(exp.amount / exp.splitAmong.length);
-        let rem = exp.amount % exp.splitAmong.length;
-        memberBalances[exp.paidBy] += exp.amount;
-        exp.splitAmong.forEach((name, idx) => {
-          const a = splitAmount + (idx < rem ? 1 : 0);
-          memberBalances[name] -= a;
-        });
-      } else if (exp.customSplits) {
-        memberBalances[exp.paidBy] += exp.amount;
-        Object.entries(exp.customSplits).forEach(([name, a]) => {
-          memberBalances[name] -= a;
-        });
-      }
-    });
-    return memberBalances;
-  };
-
-  const calculateTransfers = () => {
-    const balances = calculateSettlement();
-    const transfers: { from: string; to: string; amount: number }[] = [];
-    const debtors = Object.entries(balances).filter(([_, b]) => b < 0);
-    const creditors = Object.entries(balances).filter(([_, b]) => b > 0);
-    debtors.forEach(([debtor, debt]) => {
-      creditors.forEach(([creditor, credit]) => {
-        if (Math.abs(debt) > 0 && credit > 0) {
-          const t = Math.min(Math.abs(debt), credit);
-          transfers.push({ from: debtor, to: creditor, amount: Math.round(t) });
-          balances[debtor] += t;
-          balances[creditor] -= t;
-        }
-      });
-    });
-    return transfers.filter(t => t.amount > 0);
-  };
-
-  const balances = calculateSettlement();
-  const transfers = calculateTransfers();
+  /** ===== Render ===== */
   const totalExpenses = expenses.reduce((sum, e) => sum + e.amount, 0);
 
-  const myTransfersToReceive = transfers.filter(
-      t => t.to === currentUser && !(getPaymentStatus(t.from, t.to)?.received),
-  );
-  const myTransfersToSend = transfers.filter(
-      t => t.from === currentUser && !(getPaymentStatus(t.from, t.to)?.sent),
-  );
-  const completedTransfers = transfers.filter(
-      t => getPaymentStatus(t.from, t.to)?.sent && getPaymentStatus(t.from, t.to)?.received,
-  );
-
-  const getTransferStatusText = (from: string, to: string) => {
-    const status = getPaymentStatus(from, to);
-    if (status?.sent && status?.received) return "✅ 송금 확인됨";
-    if (status?.sent && !status?.received) return `${from}님 → 송금 완료 (확인 대기)`;
-    return `${from}님 → 아직 송금 안함`;
-  };
-
-  /** ===== Render ===== */
   return (
       <div>
-        <Tabs defaultValue="history" className="w-full">
-          <TabsList className="grid w-full grid-cols-3">
+        <Tabs
+            defaultValue="history"
+            value={activeTab}
+            onValueChange={(v) => setActiveTab(v as "history" | "my-settlement" | "overall-settlement")}
+            className="w-full"
+        >
+          <TabsList className="grid w-full grid-cols-2">
             <TabsTrigger value="history">지출 내역</TabsTrigger>
             <TabsTrigger value="my-settlement">나의 정산</TabsTrigger>
-            <TabsTrigger value="overall-settlement">전체 정산 현황</TabsTrigger>
+            {/*<TabsTrigger value="overall-settlement" onMouseEnter={prefetchOverall}>*/}
+            {/*  전체 정산 현황*/}
+            {/*</TabsTrigger>*/}
           </TabsList>
 
           {/* === 지출 내역 탭 === */}
@@ -332,19 +576,18 @@ const PaymentCalculator = ({ groupId, members, currentUser }: PaymentCalculatorP
               <CardHeader>
                 <CardTitle className="flex items-center justify-between">
                   <span>지출 내역</span>
-                  {/* 필요 시 정렬/필터 컨트롤 추가 예정 */}
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                {isLoading ? (
+                {isLoadingExpenses ? (
                     <p className="text-muted-foreground text-center py-8">불러오는 중…</p>
-                ) : isError ? (
+                ) : isErrorExpenses ? (
                     <p className="text-destructive text-center py-8">지출 목록 불러오기 실패</p>
                 ) : expenses.length === 0 ? (
                     <p className="text-muted-foreground text-center py-8">아직 지출 내역이 없습니다.</p>
                 ) : (
                     <div className="space-y-3">
-                      {expenses.map(exp => (
+                      {expenses.map((exp) => (
                           <div key={exp.id} className="flex items-center justify-between p-3 border rounded-lg">
                             <div>
                               <h4 className="font-medium">{exp.title}</h4>
@@ -403,14 +646,159 @@ const PaymentCalculator = ({ groupId, members, currentUser }: PaymentCalculatorP
             </div>
           </TabsContent>
 
-          {/* === 나의 정산 / 전체 현황 탭 ===
-            다음 단계에서 API/WS 연동으로 교체 예정 (지금은 기존 UI 계산 로직 유지) */}
+          {/* === 나의 정산 탭 === */}
           <TabsContent value="my-settlement">
-            {/* ... 기존 코드 그대로 (상단 계산 값은 expenses를 기반으로 동작) ... */}
+            <div className="space-y-6 mt-4">
+              {/* 내가 받을 돈 */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>내가 받을 돈</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {isLoadingMySettlement ? (
+                      <p className="text-muted-foreground text-center py-4">불러오는 중…</p>
+                  ) : isErrorMySettlement ? (
+                      <p className="text-destructive text-center py-4">정산 정보 불러오기 실패</p>
+                  ) : (myTransfersToReceive?.length ?? 0) === 0 ? (
+                      <p className="text-muted-foreground text-center py-4">받을 돈이 없습니다.</p>
+                  ) : (
+                      <div className="space-y-3">
+                        {myTransfersToReceive.map((t) => (
+                            <div key={t.id} className="border rounded-lg p-4 flex items-center justify-between">
+                              <div>
+                                <p className="font-medium">
+                                  {t.fromName}님이 {formatCurrency(t.amount)}을(를) 보내야 합니다.
+                                </p>
+                                <p className="text-xs text-muted-foreground">
+                                  {t.sent && !t.received ? `${t.fromName}님 → 송금 완료 (확인 대기)` : `아직 송금 안 됨`}
+                                </p>
+                              </div>
+                              <div className="flex gap-2">
+                                <Button onClick={() => nudgeMut.mutate(t.id)} disabled={nudgeMut.isPending}>
+                                  보채기
+                                </Button>
+                                <Button onClick={() => confirmMut.mutate(t.id)} disabled={!t.sent || confirmMut.isPending}>
+                                  입금 확인
+                                </Button>
+                              </div>
+                            </div>
+                        ))}
+                      </div>
+                  )}
+                </CardContent>
+              </Card>
+
+              {/* 내가 보낼 돈 */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>내가 보낼 돈</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {isLoadingMySettlement ? (
+                      <p className="text-muted-foreground text-center py-4">불러오는 중…</p>
+                  ) : isErrorMySettlement ? (
+                      <p className="text-destructive text-center py-4">정산 정보 불러오기 실패</p>
+                  ) : (myTransfersToSend?.length ?? 0) === 0 ? (
+                      <p className="text-muted-foreground text-center py-4">보낼 돈이 없습니다.</p>
+                  ) : (
+                      <div className="space-y-3">
+                        {myTransfersToSend.map((t) => (
+                            <div key={t.id} className="border rounded-lg p-4 flex items-center justify-between">
+                              <div>
+                                <p className="font-medium">
+                                  {t.toName}님에게 {formatCurrency(t.amount)}을(를) 보내야 합니다.
+                                </p>
+                                <p className="text-xs text-muted-foreground">
+                                  {t.sent ? "송금 완료 (확인 대기)" : "아직 송금 안함"}
+                                </p>
+                              </div>
+                              <div className="flex gap-2">
+                                <Button onClick={() => sendMut.mutate(t.id)} disabled={sendMut.isPending}>
+                                  보냈어요
+                                </Button>
+                              </div>
+                            </div>
+                        ))}
+                      </div>
+                  )}
+                </CardContent>
+              </Card>
+
+              {/* 완료된 정산 */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>완료된 정산</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {isLoadingMySettlement ? (
+                      <p className="text-muted-foreground text-center py-4">불러오는 중…</p>
+                  ) : isErrorMySettlement ? (
+                      <p className="text-destructive text-center py-4">정산 정보 불러오기 실패</p>
+                  ) : (completedTransfers?.length ?? 0) === 0 ? (
+                      <p className="text-muted-foreground text-center py-4">완료된 정산 내역이 없습니다.</p>
+                  ) : (
+                      <div className="space-y-3">
+                        {completedTransfers.map((t) => (
+                            <div key={t.id} className="border rounded-lg p-4 flex items-center justify-between">
+                              <div>
+                                <p className="font-medium">
+                                  {t.fromName}님 → {t.toName}님 {formatCurrency(t.amount)} 송금 완료
+                                </p>
+                                <p className="text-xs text-muted-foreground">✅ 송금 확인됨</p>
+                              </div>
+                              <Badge variant="secondary">완료</Badge>
+                            </div>
+                        ))}
+                      </div>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
           </TabsContent>
 
+          {/* === 전체 정산 현황 탭 === */}
           <TabsContent value="overall-settlement">
-            {/* ... 기존 코드 그대로 (상단 balances 기반) ... */}
+            <div className="space-y-6 mt-4">
+              <Card>
+                <CardHeader>
+                  <CardTitle>전체 정산 현황</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {isLoadingOverall ? (
+                      <p className="text-muted-foreground text-center py-4">불러오는 중…</p>
+                  ) : isErrorOverall ? (
+                      <p className="text-destructive text-center py-4">정산 현황 불러오기 실패</p>
+                  ) : !overallBalances || overallBalances.length === 0 ? (
+                      <p className="text-muted-foreground text-center py-4">정산 현황 데이터가 없습니다.</p>
+                  ) : (
+                      <div className="space-y-2">
+                        {overallBalances.map((row) => {
+                          const isPositive = row.balance > 0;
+                          const avatar = members.find((m) => Number(m.id) === row.memberId)?.avatar;
+                          return (
+                              <div key={row.memberId} className="flex justify-between items-center p-4 border rounded-md">
+                                <div className="flex items-center gap-2 text-base font-semibold">
+                                  <Avatar className="h-10 w-10">
+                                    <AvatarImage src={avatar} />
+                                    <AvatarFallback>{row.name.charAt(0)}</AvatarFallback>
+                                  </Avatar>
+                                  {row.name}
+                                </div>
+                                <div className={`text-right font-bold ${isPositive ? "text-green-600" : "text-red-600"}`}>
+                                  {isPositive ? "+" : ""}
+                                  {formatCurrency(Math.round(row.balance))}
+                                  <div className="text-xs text-muted-foreground font-normal">
+                                    {isPositive ? "받을 금액" : "낼 금액"}
+                                  </div>
+                                </div>
+                              </div>
+                          );
+                        })}
+                      </div>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
           </TabsContent>
         </Tabs>
 
@@ -538,8 +926,8 @@ const PaymentCalculator = ({ groupId, members, currentUser }: PaymentCalculatorP
                         {new Intl.NumberFormat("ko-KR").format(
                             newExpense.splitAmong.reduce(
                                 (sum, name) => sum + (newExpense.customSplits[name] || 0),
-                                0,
-                            ),
+                                0
+                            )
                         )}
                         원
                       </div>

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -116,11 +116,6 @@ const GroupDetail = () => {
     return group.members?.some(m => m.role === "OWNER") ?? false;
   }, [group, user]);
 
-  const currentUserName = useMemo(() => {
-    // 결제 컴포넌트에 넘기는 용도(임시). 실제로는 백의 내 이름을 사용하도록 교체하세요.
-    return group?.members?.[0]?.displayName ?? "나";
-  }, [group]);
-
   // 날짜 포맷
   const formatDate = (dateStr?: string | null) => {
     if (!dateStr) return "";
@@ -334,7 +329,7 @@ const GroupDetail = () => {
                 <PaymentCalculator
                     groupId={String(group.id)}
                     members={group.members.map(m => ({ id: String(m.id), name: m.displayName }))}
-                    currentUser={currentUserName}
+                    currentMemberId={Number((user as any)?.id)}
                 />
               </div>
             </TabsContent>


### PR DESCRIPTION
## 📌 개요
그룹 내 지출 내역 / 나의 정산 / 전체 정산 현황 화면을 **실제 백엔드 API 및 WebSocket 알림과 연동*

---

## 🔧 변경 사항 (What)
### 1. 지출 내역 탭
- 지출 CRUD → 총액/평균 계산 반영
- 지출 추가/삭제 시 정산 자동 커밋 실행

### 2. 나의 정산 탭
- 정산 커밋 API 연동: `POST /transfers/commit`
- 송금/입금 확인/보채기 API 연동:  
  - `POST /transfers/{id}/send`  
  - `POST /transfers/{id}/confirm`  
  - `POST /transfers/{id}/nudge`
- STOMP(WebSocket) 기반 실시간 반영
  - `TRANSFER_SENT` → 수신자 UI 업데이트
  - `TRANSFER_CONFIRMED` → 송금자 UI 업데이트

### 3. 전체 정산 현황 탭
- 멤버별 잔액 조회 API 연동: `GET /groups/{id}/settlement/overall`

### 4. 공통 사항
- **React Query**를 통한 API fetch + 캐싱 적용
- **LocalStorage 병합 전략** 적용 → 새로고침에도 상태 유지
- **Tailwind UI** 컴포넌트 기반 UI 개선

--- 

## 🔗 관련 이슈 
- Parent: [#MVP-5 정산/지출 관리](https://github.com/gatieottae/backend/issues/42)
 